### PR TITLE
limit memory used by programs

### DIFF
--- a/riscv/src/error.rs
+++ b/riscv/src/error.rs
@@ -16,6 +16,12 @@ pub enum VMError {
     /// Unknown ECALL number
     UnknownECall(u32, u32),
 
+    /// Invalid memory address
+    SegFault(u32),
+
+    /// Invalid memory alignment
+    Misaligned(u32),
+
     /// An error occurred reading file system
     IOError(std::io::Error),
 
@@ -52,10 +58,12 @@ impl Error for VMError {
 impl Display for VMError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            PartialInstruction(pc) => write!(f, "partial instruction at pc:{pc}"),
-            InvalidSize(pc, sz) => write!(f, "invalid instruction size, {sz}, at pc:{pc}"),
-            InvalidInstruction(pc, i) => write!(f, "invalid instruction {i:x} at pc:{pc}"),
-            UnknownECall(pc, n) => write!(f, "unknown ecall {n} at pc:{pc}"),
+            PartialInstruction(pc) => write!(f, "partial instruction at pc:{pc:x}"),
+            InvalidSize(pc, sz) => write!(f, "invalid instruction size, {sz}, at pc:{pc:x}"),
+            InvalidInstruction(pc, i) => write!(f, "invalid instruction {i:x} at pc:{pc:x}"),
+            UnknownECall(pc, n) => write!(f, "unknown ecall {n} at pc:{pc:x}"),
+            SegFault(addr) => write!(f, "invalid memory address {addr:x}"),
+            Misaligned(addr) => write!(f, "mis-alligned memory address {addr:x}"),
             IOError(e) => write!(f, "{e}"),
             ELFError(e) => write!(f, "{e}"),
         }

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -28,10 +28,10 @@ pub fn nop_vm(k: usize) -> VM {
 
     // TODO: we can do better for large k
     for _ in 0..k {
-        vm.mem.sw(pc, 0x00000013); // nop
+        vm.mem.sw(pc, 0x00000013).unwrap(); // nop
         pc += 4;
     }
-    vm.mem.sw(pc, 0xc0001073); // unimp
+    vm.mem.sw(pc, 0xc0001073).unwrap(); // unimp
     vm
 }
 
@@ -43,12 +43,12 @@ pub fn loop_vm(k: usize) -> VM {
 
     let hi = (k as u32) & 0xfffff000;
     let lo = ((k & 0xfff) << 20) as u32;
-    vm.mem.sw(0x1000, hi | 0x137); // lui x2, hi
-    vm.mem.sw(0x1004, lo | 0x10113); // addi x2, x2, lo
-    vm.mem.sw(0x1008, 0x00000093); // li x1, 0
-    vm.mem.sw(0x100c, 0x00108093); // addi x1, x1, 1
-    vm.mem.sw(0x1010, 0xfe209ee3); // bne x1, x2, 0x100c
-    vm.mem.sw(0x1014, 0xc0001073); // unimp
+    vm.mem.sw(0x1000, hi | 0x137).unwrap(); // lui x2, hi
+    vm.mem.sw(0x1004, lo | 0x10113).unwrap(); // addi x2, x2, lo
+    vm.mem.sw(0x1008, 0x00000093).unwrap(); // li x1, 0
+    vm.mem.sw(0x100c, 0x00108093).unwrap(); // addi x1, x1, 1
+    vm.mem.sw(0x1010, 0xfe209ee3).unwrap(); // bne x1, x2, 0x100c
+    vm.mem.sw(0x1014, 0xc0001073).unwrap(); // unimp
     vm
 }
 
@@ -76,7 +76,7 @@ pub fn parse_elf(bytes: &[u8]) -> Result<VM> {
         let s = p.p_offset as usize;
         let e = (p.p_offset + p.p_filesz) as usize;
         let bytes = &bytes[s..e];
-        vm.init_memory(p.p_vaddr as u32, bytes);
+        vm.init_memory(p.p_vaddr as u32, bytes)?;
     }
 
     Ok(vm)

--- a/riscv/src/vm/mem.rs
+++ b/riscv/src/vm/mem.rs
@@ -1,100 +1,251 @@
-// RISC-V leaves the meaning of misaligned loads and stores
-// up to the Execution Environment Interface (EEI).
-// Our expectation is that front-end compilers targeting
-// the basic instruction set(s) will not emit misaligned
-// loads and stores. Best efforts will be made to accommodate
-// misaligned loads and stores, but there is no guarantee
-// that such code will execute without exception.
+// RISC-V leaves the meaning of misaligned loads and stores up to the Execution Environment
+// Interface (EEI).  Our expectation is that front-end compilers targeting the basic instruction
+// set(s) will not emit misaligned loads and stores.  The memory circuits depend on this
+// assumption, and we check it here to catch any violations early.
 
 use std::collections::BTreeMap;
+use crate::error::*;
+use VMError::{SegFault, Misaligned};
 
-/// A simple memory for RV32
+// This array defines the memory map of the machine.
+
+#[rustfmt::skip]
+#[allow(non_upper_case_globals)]
+const memory_map: [(u32,u32,u32); 3] = [
+    //  virtual     size     phys
+    (0x00001000, 0x100000,        0),
+    (0x10000000, 0x2f0000, 0x100000),
+    (0xfffeffff, 0x010000, 0x3f0000),
+];
+
+/// Convert a virtual address to a physical address.
 ///
-/// Memory is organized as a collection of 4K pages.
-/// A binary tree is used to represent a sparsely
-/// populated memory space of 4K pages.
+/// This function will fail if the virtual addresss is not mapped (a.k.a. seg-fault).
 
-#[derive(Default)]
-pub struct Mem {
-    tree: BTreeMap<u32, Page>,
+pub const fn virt2phys(addr: u32) -> Result<u32> {
+    let mut i = 0;
+    loop {
+        if i >= memory_map.len() {
+            break;
+        }
+        let (start, length, phys) = memory_map[i];
+        if addr >= start && addr < start + length {
+            return Ok(addr - start + phys);
+        }
+        i += 1
+    }
+    Err(SegFault(addr))
 }
-type Page = [u8; 4096];
 
-impl Mem {
-    pub(crate) fn wr_page(&mut self, addr: u32) -> &mut [u8] {
-        let page = addr >> 12;
-        let offset = (addr & 0xfff) as usize;
-        let arr = self.tree.entry(page).or_insert_with(|| [0u8; 4096]);
-        &mut arr[offset..]
+// A Cell represents a location in memory with little-endian layout
+
+#[derive(Copy, Clone)]
+pub union Cell {
+    words: u32,
+    halfs: [u16; 2],
+    bytes: [u8; 4],
+}
+
+// This will generate a compile error if Cell is not 4 bytes as expected
+const _: fn() = || {
+    let _ = core::mem::transmute::<Cell, u32>;
+};
+
+impl Default for Cell {
+    fn default() -> Self {
+        Cell::from(0u32)
+    }
+}
+
+impl From<u32> for Cell {
+    fn from(word: u32) -> Self {
+        Cell { words: word }
+    }
+}
+
+impl Cell {
+    pub fn bytes(&self) -> &[u8] {
+        unsafe { &self.bytes }
     }
 
-    pub(crate) fn rd_page(&self, addr: u32) -> &[u8] {
-        let page = addr >> 12;
-        let offset = (addr & 0xfff) as usize;
+    pub fn lbu(&self, addr: u32) -> u8 {
+        unsafe { self.bytes[(addr & 0b11) as usize] }
+    }
 
-        static ZEROS: [u8; 4] = [0; 4];
-        match self.tree.get(&page) {
-            None => &ZEROS,
-            Some(arr) => &arr[offset..],
+    pub fn lhu(&self, addr: u32) -> Result<u16> {
+        if (addr & 1) != 0 {
+            return Err(Misaligned(addr));
+        }
+        unsafe { Ok(self.halfs[((addr >> 1) & 1) as usize]) }
+    }
+
+    pub fn lw(&self, addr: u32) -> Result<u32> {
+        if (addr & 3) != 0 {
+            return Err(Misaligned(addr));
+        }
+        unsafe { Ok(self.words) }
+    }
+
+    pub fn sb(&mut self, addr: u32, val: u8) {
+        unsafe {
+            self.bytes[(addr & 0b11) as usize] = val;
         }
     }
 
+    pub fn sh(&mut self, addr: u32, val: u16) -> Result<()> {
+        if (addr & 1) != 0 {
+            return Err(Misaligned(addr));
+        }
+        unsafe {
+            self.halfs[((addr >> 1) & 1) as usize] = val;
+        }
+        Ok(())
+    }
+
+    pub fn sw(&mut self, addr: u32, val: u32) -> Result<()> {
+        if (addr & 3) != 0 {
+            return Err(Misaligned(addr));
+        }
+        self.words = val;
+        Ok(())
+    }
+}
+
+/// An interface for Cell containers. All addresses must be 4-byte aligned.
+
+pub trait Cells {
+    /// returns a refernce to the cell at address `addr`.
+    fn cell(&self, addr: u32) -> &Cell;
+
+    /// returns a mutable refernce to the cell at address `addr`.
+    fn cell_mut(&mut self, addr: u32) -> &mut Cell;
+}
+
+/// The memory of the machine, implemented by a Cell container, T.
+
+#[derive(Default)]
+pub struct Memory<T: Cells>(T);
+
+impl<T: Cells> Memory<T> {
+    /// return cell at address (must be 32-bit aligned)
+    pub fn read_cell(&self, addr: u32) -> Result<&Cell> {
+        let addr = virt2phys(addr)?;
+        Ok(self.0.cell(addr))
+    }
+
     /// store the lowest byte of val at addr
-    pub fn sb(&mut self, addr: u32, val: u32) {
-        self.wr_page(addr)[0] = (val & 0xff) as u8;
+    pub fn sb(&mut self, addr: u32, val: u32) -> Result<()> {
+        let addr = virt2phys(addr)?;
+        self.0.cell_mut(addr).sb(addr, val as u8);
+        Ok(())
     }
 
     /// store the lowest two bytes of val at addr
-    pub fn sh(&mut self, addr: u32, val: u32) {
-        let arr = self.wr_page(addr);
-        arr[0] = (val & 0xff) as u8;
-        arr[1] = ((val >> 8) & 0xff) as u8;
+    pub fn sh(&mut self, addr: u32, val: u32) -> Result<()> {
+        let addr = virt2phys(addr)?;
+        self.0.cell_mut(addr).sh(addr, val as u16)
     }
 
     /// store val at addr
-    pub fn sw(&mut self, addr: u32, val: u32) {
-        let arr = self.wr_page(addr);
-        arr[0] = (val & 0xff) as u8;
-        arr[1] = ((val >> 8) & 0xff) as u8;
-        arr[2] = ((val >> 16) & 0xff) as u8;
-        arr[3] = ((val >> 24) & 0xff) as u8;
+    pub fn sw(&mut self, addr: u32, val: u32) -> Result<()> {
+        let addr = virt2phys(addr)?;
+        self.0.cell_mut(addr).sw(addr, val)
     }
 
     /// load byte at addr, zero-extended
-    pub fn lbu(&self, addr: u32) -> u32 {
-        self.rd_page(addr)[0] as u32
+    pub fn lbu(&self, addr: u32) -> Result<u32> {
+        let addr = virt2phys(addr)?;
+        Ok(self.0.cell(addr).lbu(addr) as u32)
     }
 
     /// load 16-bit value at addr, zero-extended
-    pub fn lhu(&self, addr: u32) -> u32 {
-        let arr = self.rd_page(addr);
-        (arr[0] as u32) | (arr[1] as u32) << 8
+    pub fn lhu(&self, addr: u32) -> Result<u32> {
+        let addr = virt2phys(addr)?;
+        Ok(self.0.cell(addr).lhu(addr)? as u32)
     }
 
     /// load 32-bit value at addr
-    pub fn lw(&self, addr: u32) -> u32 {
-        let arr = self.rd_page(addr);
-        (arr[0] as u32) | (arr[1] as u32) << 8 | (arr[2] as u32) << 16 | (arr[3] as u32) << 24
+    pub fn lw(&self, addr: u32) -> Result<u32> {
+        let addr = virt2phys(addr)?;
+        self.0.cell(addr).lw(addr)
     }
 
     /// load byte at addr, sign-extended
-    pub fn lb(&self, addr: u32) -> u32 {
-        let val = self.lbu(addr);
+    pub fn lb(&self, addr: u32) -> Result<u32> {
+        let val = self.lbu(addr)?;
         if val & 0x80 == 0 {
-            val
+            Ok(val)
         } else {
-            0xffffff00 | val
+            Ok(0xffffff00 | val)
         }
     }
 
     /// load 16-bit value at addr, sign-extended
-    pub fn lh(&self, addr: u32) -> u32 {
-        let val = self.lhu(addr);
+    pub fn lh(&self, addr: u32) -> Result<u32> {
+        let val = self.lhu(addr)?;
         if val & 0x8000 == 0 {
-            val
+            Ok(val)
         } else {
-            0xffff0000 | val
+            Ok(0xffff0000 | val)
         }
+    }
+}
+
+/// Default memory type
+
+pub type Mem = Memory<ArrayMem>;
+
+/// A paged memory suitable for large address spaces
+///
+/// A binary tree is used to represent a sparsely
+/// populated memory space of 4K pages.
+
+#[derive(Default)]
+pub struct PagedMem {
+    tree: BTreeMap<u32, Page>,
+}
+type Page = [Cell; 1024];
+
+impl Cells for PagedMem {
+    fn cell(&self, addr: u32) -> &Cell {
+        let page = addr >> 12;
+        let offset = ((addr & 0xfff) >> 2) as usize;
+        let cells = self.tree.get(&page).unwrap();
+        &cells[offset]
+    }
+
+    fn cell_mut(&mut self, addr: u32) -> &mut Cell {
+        let page = addr >> 12;
+        let offset = ((addr & 0xfff) >> 2) as usize;
+        let cells = self
+            .tree
+            .entry(page)
+            .or_insert_with(|| [Cell::default(); 1024]);
+        &mut cells[offset]
+    }
+}
+
+/// A linear array memory suitable for small address spaces
+
+pub struct ArrayMem {
+    array: Vec<Cell>,
+}
+
+impl Default for ArrayMem {
+    fn default() -> Self {
+        Self { array: vec![Cell::default(); 0x100000] }
+    }
+}
+
+impl Cells for ArrayMem {
+    fn cell(&self, addr: u32) -> &Cell {
+        let offset = (addr >> 2) as usize;
+        &self.array[offset]
+    }
+
+    fn cell_mut(&mut self, addr: u32) -> &mut Cell {
+        let offset = (addr >> 2) as usize;
+        &mut self.array[offset]
     }
 }
 
@@ -103,47 +254,68 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_mem() {
-        let mut mem = Mem::default();
-        mem.sb(0x100, 1);
-        mem.sb(0x101, 2);
-        mem.sb(0x103, 3);
-        mem.sb(0x104, 4);
-        mem.sb(0x1000, 1);
-        assert_eq!(mem.tree.len(), 2);
+    fn test_le() {
+        let mut cell = Cell::from(0x01020304);
+        assert_eq!(cell.lw(0).unwrap(), 0x01020304);
+        assert_eq!(cell.lhu(0).unwrap(), 0x0304);
+        assert_eq!(cell.lhu(2).unwrap(), 0x0102);
+        assert_eq!(cell.lbu(0), 4);
+        assert_eq!(cell.lbu(1), 3);
+        assert_eq!(cell.lbu(2), 2);
+        assert_eq!(cell.lbu(3), 1);
 
-        assert_eq!(mem.lbu(0xff), 0);
-        assert_eq!(mem.lbu(0x100), 1);
-        assert_eq!(mem.lbu(0x101), 2);
-        assert_eq!(mem.lbu(0x103), 3);
-        assert_eq!(mem.lbu(0x104), 4);
-        assert_eq!(mem.lbu(0x105), 0);
-        assert_eq!(mem.lbu(0x1000), 1);
-        assert_eq!(mem.lbu(0x1001), 0);
+        cell.sb(0, 4);
+        cell.sb(1, 5);
+        cell.sb(2, 6);
+        cell.sb(3, 7);
+        assert_eq!(cell.lw(0).unwrap(), 0x07060504);
 
-        mem.sh(0x100, 0x708);
-        assert_eq!(mem.tree.len(), 2);
-        assert_eq!(mem.lbu(0x100), 8);
-        assert_eq!(mem.lbu(0x101), 7);
-        assert_eq!(mem.lhu(0x100), 0x708);
-        assert_eq!(mem.lhu(0xff), 0x800);
-        assert_eq!(mem.lhu(0x101), 7);
-        assert_eq!(mem.lhu(0x200), 0);
+        cell.sh(0, 0x0a0b).unwrap();
+        cell.sh(2, 0x0c0d).unwrap();
+        assert_eq!(cell.lw(0).unwrap(), 0x0c0d0a0b);
+    }
 
-        mem.sw(0x200, 0x10203040);
-        assert_eq!(mem.tree.len(), 2);
-        assert_eq!(mem.lbu(0x200), 0x40);
-        assert_eq!(mem.lbu(0x201), 0x30);
-        assert_eq!(mem.lbu(0x202), 0x20);
-        assert_eq!(mem.lbu(0x203), 0x10);
-        assert_eq!(mem.lhu(0x200), 0x3040);
-        assert_eq!(mem.lhu(0x202), 0x1020);
-        assert_eq!(mem.lw(0x200), 0x10203040);
+    fn test_mem<T: Cells>(mut mem: Memory<T>) {
+        mem.sb(0x1100, 1).unwrap();
+        mem.sb(0x1101, 2).unwrap();
+        mem.sb(0x1103, 3).unwrap();
+        mem.sb(0x1104, 4).unwrap();
+        mem.sb(0x11000, 1).unwrap();
 
-        mem.sb(0x300, 0x81);
-        assert_eq!(mem.lb(0x300), 0xffffff81);
+        assert_eq!(mem.lbu(0x10ff).unwrap(), 0);
+        assert_eq!(mem.lbu(0x1100).unwrap(), 1);
+        assert_eq!(mem.lbu(0x1101).unwrap(), 2);
+        assert_eq!(mem.lbu(0x1103).unwrap(), 3);
+        assert_eq!(mem.lbu(0x1104).unwrap(), 4);
+        assert_eq!(mem.lbu(0x1105).unwrap(), 0);
+        assert_eq!(mem.lbu(0x11000).unwrap(), 1);
+        assert_eq!(mem.lbu(0x11001).unwrap(), 0);
 
-        mem.sh(0x300, 0x8321);
-        assert_eq!(mem.lh(0x300), 0xffff8321);
+        mem.sh(0x1100, 0x708).unwrap();
+        assert_eq!(mem.lbu(0x1100).unwrap(), 8);
+        assert_eq!(mem.lbu(0x1101).unwrap(), 7);
+        assert_eq!(mem.lhu(0x1100).unwrap(), 0x708);
+        assert_eq!(mem.lhu(0x1200).unwrap(), 0);
+
+        mem.sw(0x1200, 0x10203040).unwrap();
+        assert_eq!(mem.lbu(0x1200).unwrap(), 0x40);
+        assert_eq!(mem.lbu(0x1201).unwrap(), 0x30);
+        assert_eq!(mem.lbu(0x1202).unwrap(), 0x20);
+        assert_eq!(mem.lbu(0x1203).unwrap(), 0x10);
+        assert_eq!(mem.lhu(0x1200).unwrap(), 0x3040);
+        assert_eq!(mem.lhu(0x1202).unwrap(), 0x1020);
+        assert_eq!(mem.lw(0x1200).unwrap(), 0x10203040);
+
+        mem.sb(0x1300, 0x81).unwrap();
+        assert_eq!(mem.lb(0x1300).unwrap(), 0xffffff81);
+
+        mem.sh(0x1300, 0x8321).unwrap();
+        assert_eq!(mem.lh(0x1300).unwrap(), 0xffff8321);
+    }
+
+    #[test]
+    fn test_memory() {
+        test_mem(Memory::<PagedMem>::default());
+        test_mem(Memory::<ArrayMem>::default());
     }
 }


### PR DESCRIPTION
This patch introduces a virtual address space. All memory addresses are mapped to physical addresses, which must fit into a predetermined range. In addition, the memory can now use different data structures to manage the heap (in anticipation of using a Merkle tree for traces).

Note, the debug builds of fact and fib1000 will not run under the memory constraints in this patch.