### PR TITLE
cleanup commitment scheme bounds

### DIFF
--- a/supernova/src/absorb.rs
+++ b/supernova/src/absorb.rs
@@ -20,7 +20,10 @@ use ark_ec::{
 };
 use ark_ff::PrimeField;
 
-use super::{commitment::CommitmentScheme, utils::cast_field_element_unique};
+use super::{
+    commitment::{Commitment, CommitmentScheme},
+    utils::cast_field_element_unique,
+};
 use crate::r1cs::{R1CSInstance, RelaxedR1CSInstance};
 
 /// An interface to objects that can be absorbed by [`ark_sponge::CryptographicSponge`] defined
@@ -72,7 +75,7 @@ where
     P::ScalarField: Absorb,
 {
     fn to_non_native_field_elements(&self, dest: &mut Vec<P::ScalarField>) {
-        let affine = self.into_affine();
+        let affine = <Self as CurveGroup>::into_affine(*self);
 
         let x = cast_field_element_unique::<P::BaseField, P::ScalarField>(&affine.x);
         let y = cast_field_element_unique::<P::BaseField, P::ScalarField>(&affine.y);
@@ -90,7 +93,7 @@ where
     G: CurveGroup,
     G::BaseField: PrimeField + Absorb,
     G::Affine: Absorb,
-    C: CommitmentScheme<G, Commitment = G>,
+    C: CommitmentScheme<G>,
 {
     fn to_non_native_field_elements(&self, dest: &mut Vec<G::BaseField>) {
         Absorb::to_sponge_field_elements(&self.commitment_W.into_affine(), dest);
@@ -108,7 +111,7 @@ where
     G: CurveGroup,
     G::BaseField: PrimeField + Absorb,
     G::Affine: Absorb,
-    C: CommitmentScheme<G, Commitment = G>,
+    C: CommitmentScheme<G>,
 {
     fn to_non_native_field_elements(&self, dest: &mut Vec<G::BaseField>) {
         Absorb::to_sponge_field_elements(&self.commitment_W.into_affine(), dest);

--- a/supernova/src/circuits/nova/pcd/augmented.rs
+++ b/supernova/src/circuits/nova/pcd/augmented.rs
@@ -17,7 +17,7 @@ use ark_relations::{
     lc,
     r1cs::{ConstraintSystemRef, Namespace, SynthesisError, Variable},
 };
-use ark_std::{fmt::Debug, Zero};
+use ark_std::Zero;
 
 use crate::{
     circuits::{NovaConstraintSynthesizer, StepCircuit},
@@ -42,8 +42,7 @@ where
     G1: SWCurveConfig,
     G2: SWCurveConfig,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     Base {
         vk: G1::ScalarField,
@@ -58,8 +57,7 @@ where
     G1: SWCurveConfig,
     G2: SWCurveConfig,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     pub vk: G1::ScalarField,
 
@@ -80,8 +78,7 @@ where
     G1: SWCurveConfig,
     G2: SWCurveConfig,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -103,8 +100,7 @@ where
     G1: SWCurveConfig,
     G2: SWCurveConfig,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     pub U: RelaxedR1CSInstance<G1, C1>,
     pub U_secondary: RelaxedR1CSInstance<G2, C2>,
@@ -118,8 +114,7 @@ where
     G1: SWCurveConfig,
     G2: SWCurveConfig,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -139,8 +134,7 @@ where
     G1::BaseField: PrimeField,
     G2::BaseField: PrimeField,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     U: primary::RelaxedR1CSInstanceVar<G1, C1>,
     U_secondary: secondary::RelaxedR1CSInstanceVar<G2, C2>,
@@ -160,8 +154,7 @@ where
     G1::BaseField: PrimeField,
     G2::BaseField: PrimeField,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>> + From<Projective<G1>> + Debug + Eq,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO: SpongeWithGadget<G1::ScalarField>,
     RO::Var: CryptographicSpongeVar<G1::ScalarField, RO, Parameters = RO::Config>,
 {
@@ -196,8 +189,7 @@ where
     G1::BaseField: PrimeField,
     G2::BaseField: PrimeField,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO: SpongeWithGadget<G1::ScalarField>,
 {
     vk: FpVar<G1::ScalarField>,
@@ -228,8 +220,7 @@ where
     G1::BaseField: PrimeField,
     G2::BaseField: PrimeField,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO: SpongeWithGadget<G1::ScalarField>,
     RO::Var: CryptographicSpongeVar<G1::ScalarField, RO, Parameters = RO::Config>,
 {
@@ -288,8 +279,7 @@ where
     G1::BaseField: PrimeField,
     G2::BaseField: PrimeField,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>> + From<Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO: SpongeWithGadget<G1::ScalarField>,
     RO::Var: CryptographicSpongeVar<G1::ScalarField, RO, Parameters = RO::Config>,
 {
@@ -369,11 +359,11 @@ where
         let commitment_T =
             NonNativeAffineVar::new_variable(cs.clone(), || Ok(&commitment_T_point), mode)?;
         let commitment_T_secondary = <ProjectiveVar<G2, FpVar<G2::BaseField>> as AllocVar<
-            C2::Commitment,
+            Projective<G2>,
             G2::BaseField,
         >>::new_variable(
             cs.clone(),
-            || Ok(&input.proof.proof_secondary.commitment_T),
+            || Ok(input.proof.proof_secondary.commitment_T.into()),
             mode,
         )?;
         let u_secondary = (
@@ -417,8 +407,7 @@ where
     G1: SWCurveConfig,
     G2: SWCurveConfig,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO: SpongeWithGadget<G1::ScalarField>,
     SC: StepCircuit<G1::ScalarField>,
 {
@@ -432,8 +421,7 @@ where
     G1: SWCurveConfig,
     G2: SWCurveConfig,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO: SpongeWithGadget<G1::ScalarField>,
     SC: StepCircuit<G1::ScalarField>,
 {
@@ -458,8 +446,7 @@ where
     G1::BaseField: PrimeField + Absorb,
     G2::BaseField: PrimeField + Absorb,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>> + From<Projective<G1>> + Eq + Debug,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO: SpongeWithGadget<G1::ScalarField>,
     RO::Var: CryptographicSpongeVar<G1::ScalarField, RO, Parameters = RO::Config>,
     SC: StepCircuit<G1::ScalarField>,
@@ -493,8 +480,8 @@ where
         let U_secondary_base = secondary::RelaxedR1CSInstanceVar::<G2, C2>::new_constant(
             cs.clone(),
             RelaxedR1CSInstance {
-                commitment_W: Projective::zero(),
-                commitment_E: Projective::zero(),
+                commitment_W: Projective::zero().into(),
+                commitment_E: Projective::zero().into(),
                 X: vec![G2::ScalarField::ZERO; SecondaryCircuit::<G1>::NUM_IO],
             },
         )?;
@@ -626,8 +613,8 @@ mod tests {
         G2: SWCurveConfig<BaseField = G1::ScalarField, ScalarField = G1::BaseField>,
         G1::BaseField: PrimeField + Absorb,
         G2::BaseField: PrimeField + Absorb,
-        C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>>,
-        C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+        C1: CommitmentScheme<Projective<G1>>,
+        C2: CommitmentScheme<Projective<G2>>,
         C1::PP: Clone,
     {
         let ro_config = poseidon_config();

--- a/supernova/src/circuits/nova/pcd/compression/commitment_utils.rs
+++ b/supernova/src/circuits/nova/pcd/compression/commitment_utils.rs
@@ -19,7 +19,7 @@ where
 impl<G: CurveGroup, PC: PolyCommitmentScheme<G>> CommitmentScheme<G> for PolyVectorCommitment<G, PC>
 where
     G: CurveGroup,
-    PC::Commitment: Copy,
+    PC::Commitment: Copy + Into<G> + From<G>,
 {
     type SetupAux = PC::SRS;
     type PP = PCSKeys<G, PC>;

--- a/supernova/src/circuits/nova/pcd/compression/conversion.rs
+++ b/supernova/src/circuits/nova/pcd/compression/conversion.rs
@@ -69,7 +69,7 @@ impl<G, PC> TryFrom<RelaxedR1CSInstance<G, PolyVectorCommitment<Projective<G>, P
 where
     G: SWCurveConfig,
     PC: PolyCommitmentScheme<Projective<G>>,
-    PC::Commitment: Copy,
+    PC::Commitment: Copy + Into<Projective<G>> + From<Projective<G>>,
 {
     type Error = ConversionError;
     fn try_from(
@@ -126,7 +126,7 @@ mod tests {
         G: SWCurveConfig,
         G::BaseField: PrimeField,
         PC: PolyCommitmentScheme<Projective<G>>,
-        PC::Commitment: Copy + Into<Projective<G>>,
+        PC::Commitment: Copy + Into<Projective<G>> + From<Projective<G>>,
     {
         let mut rng = test_rng();
         let srs = PC::setup(3, b"test_srs_cubic", &mut rng)

--- a/supernova/src/circuits/nova/pcd/compression/mod.rs
+++ b/supernova/src/circuits/nova/pcd/compression/mod.rs
@@ -39,7 +39,7 @@ pub struct CompressedPCDProof<G1, G2, PC, C2, RO, SC>
 where
     G1: SWCurveConfig,
     G2: SWCurveConfig,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     PC: PolyCommitmentScheme<Projective<G1>>,
     PC::Commitment: Into<Projective<G1>> + From<Projective<G1>> + Copy,
     RO: SpongeWithGadget<G1::ScalarField> + Send + Sync,
@@ -95,7 +95,7 @@ where
     G2: SWCurveConfig<BaseField = G1::ScalarField, ScalarField = G1::BaseField>,
     G1::BaseField: PrimeField + Absorb,
     G2::BaseField: PrimeField + Absorb,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     PC: PolyCommitmentScheme<Projective<G1>>,
     PC::Commitment: Copy + Into<Projective<G1>> + From<Projective<G1>>,
     RO: SpongeWithGadget<G1::ScalarField> + Send + Sync,
@@ -304,7 +304,7 @@ mod tests {
         G2::BaseField: PrimeField + Absorb,
         PC: PolyCommitmentScheme<Projective<G1>>,
         PC::Commitment: Copy + Into<Projective<G1>> + From<Projective<G1>>,
-        C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>, SetupAux = ()>,
+        C2: CommitmentScheme<Projective<G2>, SetupAux = ()>,
     {
         // we hardcode the minimum SRS size here for simplicity. If we need to derive it, we can do:
         // let shape = setup_shape(ro_config, step_circuit).unwrap();
@@ -345,7 +345,7 @@ mod tests {
         G2: SWCurveConfig<BaseField = G1::ScalarField, ScalarField = G1::BaseField>,
         G1::BaseField: PrimeField + Absorb,
         G2::BaseField: PrimeField + Absorb,
-        C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>, SetupAux = ()>,
+        C2: CommitmentScheme<Projective<G2>, SetupAux = ()>,
         PC: PolyCommitmentScheme<Projective<G1>>,
         PC::Commitment: Copy + Into<Projective<G1>> + From<Projective<G1>>,
     {

--- a/supernova/src/circuits/nova/pcd/mod.rs
+++ b/supernova/src/circuits/nova/pcd/mod.rs
@@ -9,7 +9,6 @@ use ark_ff::{AdditiveGroup, PrimeField};
 use ark_r1cs_std::R1CSVar;
 use ark_relations::r1cs::{ConstraintSystem, SynthesisMode};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
-use ark_std::fmt::Debug;
 
 use super::{public_params, NovaConstraintSynthesizer, StepCircuit};
 use crate::{
@@ -46,8 +45,7 @@ where
     G1::BaseField: PrimeField + Absorb,
     G2::BaseField: PrimeField + Absorb,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>> + From<Projective<G1>> + Eq + Debug,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO: SpongeWithGadget<G1::ScalarField> + Send + Sync,
     RO::Var: CryptographicSpongeVar<G1::ScalarField, RO, Parameters = RO::Config>,
     RO::Config: CanonicalSerialize + CanonicalDeserialize + Sync,
@@ -152,8 +150,7 @@ where
     G1::BaseField: PrimeField + Absorb,
     G2::BaseField: PrimeField + Absorb,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>> + From<Projective<G1>> + Debug + Eq,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO: SpongeWithGadget<G1::ScalarField> + Send + Sync,
     RO::Var: CryptographicSpongeVar<G1::ScalarField, RO, Parameters = RO::Config>,
     RO::Config: CanonicalSerialize + CanonicalDeserialize + Sync,
@@ -465,8 +462,8 @@ mod tests {
         G2: SWCurveConfig<BaseField = G1::ScalarField, ScalarField = G1::BaseField>,
         G1::BaseField: PrimeField + Absorb,
         G2::BaseField: PrimeField + Absorb,
-        C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>, SetupAux = ()>,
-        C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>, SetupAux = ()>,
+        C1: CommitmentScheme<Projective<G1>, SetupAux = ()>,
+        C2: CommitmentScheme<Projective<G2>, SetupAux = ()>,
     {
         let ro_config = poseidon_config();
 
@@ -508,8 +505,8 @@ mod tests {
         G2: SWCurveConfig<BaseField = G1::ScalarField, ScalarField = G1::BaseField>,
         G1::BaseField: PrimeField + Absorb,
         G2::BaseField: PrimeField + Absorb,
-        C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>, SetupAux = ()>,
-        C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>, SetupAux = ()>,
+        C1: CommitmentScheme<Projective<G1>, SetupAux = ()>,
+        C2: CommitmentScheme<Projective<G2>, SetupAux = ()>,
     {
         let filter = filter::Targets::new().with_target(SUPERNOVA_TARGET, tracing::Level::DEBUG);
         let _guard = tracing_subscriber::registry()

--- a/supernova/src/circuits/nova/sequential/augmented.rs
+++ b/supernova/src/circuits/nova/sequential/augmented.rs
@@ -38,8 +38,8 @@ pub enum NovaAugmentedCircuitInput<G1, G2, C1, C2, RO>
 where
     G1: SWCurveConfig,
     G2: SWCurveConfig,
-    C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C1: CommitmentScheme<Projective<G1>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     Base {
         vk: G1::ScalarField,
@@ -52,8 +52,8 @@ pub struct NovaAugmentedCircuitNonBaseInput<G1, G2, C1, C2, RO>
 where
     G1: SWCurveConfig,
     G2: SWCurveConfig,
-    C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C1: CommitmentScheme<Projective<G1>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     pub vk: G1::ScalarField,
     pub i: G1::ScalarField,
@@ -69,8 +69,8 @@ impl<G1, G2, C1, C2, RO> Clone for NovaAugmentedCircuitNonBaseInput<G1, G2, C1, 
 where
     G1: SWCurveConfig,
     G2: SWCurveConfig,
-    C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C1: CommitmentScheme<Projective<G1>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -92,8 +92,8 @@ where
     G2: SWCurveConfig,
     G1::BaseField: PrimeField,
     G2::BaseField: PrimeField,
-    C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C1: CommitmentScheme<Projective<G1>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO: SpongeWithGadget<G1::ScalarField>,
 {
     vk: FpVar<G1::ScalarField>,
@@ -118,8 +118,8 @@ where
     G2: SWCurveConfig<BaseField = G1::ScalarField, ScalarField = G1::BaseField>,
     G1::BaseField: PrimeField,
     G2::BaseField: PrimeField,
-    C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C1: CommitmentScheme<Projective<G1>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO: SpongeWithGadget<G1::ScalarField>,
     RO::Var: CryptographicSpongeVar<G1::ScalarField, RO, Parameters = RO::Config>,
 {
@@ -144,7 +144,7 @@ where
                 let U_secondary = RelaxedR1CSInstance::<G2, C2>::new(&shape_secondary);
                 let u = R1CSInstance::<G1, C1>::new(
                     &shape,
-                    &Projective::zero(),
+                    &Projective::zero().into(),
                     &[G1::ScalarField::ONE; AUGMENTED_CIRCUIT_NUM_IO],
                 )
                 .unwrap();
@@ -182,8 +182,11 @@ where
         )?;
         let u = primary::R1CSInstanceVar::new_variable(cs.clone(), || Ok(&input.u), mode)?;
 
-        let commitment_T =
-            NonNativeAffineVar::new_variable(cs.clone(), || Ok(&input.proof.commitment_T), mode)?;
+        let commitment_T = NonNativeAffineVar::new_variable(
+            cs.clone(),
+            || Ok(input.proof.commitment_T.into()),
+            mode,
+        )?;
 
         let u_secondary = (
             secondary::ProofVar::new_variable(
@@ -217,8 +220,8 @@ pub struct NovaAugmentedCircuit<'a, G1, G2, C1, C2, RO, SC>
 where
     G1: SWCurveConfig,
     G2: SWCurveConfig,
-    C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C1: CommitmentScheme<Projective<G1>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO: SpongeWithGadget<G1::ScalarField>,
     SC: StepCircuit<G1::ScalarField>,
 {
@@ -231,8 +234,8 @@ impl<'a, G1, G2, C1, C2, RO, SC> NovaAugmentedCircuit<'a, G1, G2, C1, C2, RO, SC
 where
     G1: SWCurveConfig,
     G2: SWCurveConfig,
-    C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C1: CommitmentScheme<Projective<G1>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO: SpongeWithGadget<G1::ScalarField>,
     SC: StepCircuit<G1::ScalarField>,
 {
@@ -256,8 +259,8 @@ where
     G2: SWCurveConfig<BaseField = G1::ScalarField, ScalarField = G1::BaseField>,
     G1::BaseField: PrimeField + Absorb,
     G2::BaseField: PrimeField + Absorb,
-    C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C1: CommitmentScheme<Projective<G1>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO: SpongeWithGadget<G1::ScalarField>,
     RO::Var: CryptographicSpongeVar<G1::ScalarField, RO, Parameters = RO::Config>,
     SC: StepCircuit<G1::ScalarField>,
@@ -277,16 +280,16 @@ where
         let U_base = primary::RelaxedR1CSInstanceVar::<G1, C1>::new_constant(
             cs.clone(),
             RelaxedR1CSInstance {
-                commitment_W: Projective::zero(),
-                commitment_E: Projective::zero(),
+                commitment_W: Projective::zero().into(),
+                commitment_E: Projective::zero().into(),
                 X: vec![G1::ScalarField::ZERO; AUGMENTED_CIRCUIT_NUM_IO],
             },
         )?;
         let U_secondary_base = secondary::RelaxedR1CSInstanceVar::<G2, C2>::new_constant(
             cs.clone(),
             RelaxedR1CSInstance {
-                commitment_W: Projective::zero(),
-                commitment_E: Projective::zero(),
+                commitment_W: Projective::zero().into(),
+                commitment_E: Projective::zero().into(),
                 X: vec![G2::ScalarField::ZERO; SecondaryCircuit::<G1>::NUM_IO],
             },
         )?;
@@ -390,8 +393,8 @@ mod tests {
         G2: SWCurveConfig<BaseField = G1::ScalarField, ScalarField = G1::BaseField>,
         G1::BaseField: PrimeField + Absorb,
         G2::BaseField: PrimeField + Absorb,
-        C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>>,
-        C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+        C1: CommitmentScheme<Projective<G1>>,
+        C2: CommitmentScheme<Projective<G2>>,
         C1::PP: Clone,
     {
         let ro_config = poseidon_config();

--- a/supernova/src/circuits/nova/sequential/mod.rs
+++ b/supernova/src/circuits/nova/sequential/mod.rs
@@ -41,8 +41,8 @@ where
     G2: SWCurveConfig<BaseField = G1::ScalarField, ScalarField = G1::BaseField>,
     G1::BaseField: PrimeField + Absorb,
     G2::BaseField: PrimeField + Absorb,
-    C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C1: CommitmentScheme<Projective<G1>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO: SpongeWithGadget<G1::ScalarField> + Send + Sync,
     RO::Var: CryptographicSpongeVar<G1::ScalarField, RO, Parameters = RO::Config>,
     RO::Config: CanonicalSerialize + CanonicalDeserialize + Sync,
@@ -188,8 +188,8 @@ where
     G2: SWCurveConfig<BaseField = G1::ScalarField, ScalarField = G1::BaseField>,
     G1::BaseField: PrimeField + Absorb,
     G2::BaseField: PrimeField + Absorb,
-    C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C1: CommitmentScheme<Projective<G1>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO: SpongeWithGadget<G1::ScalarField> + Send + Sync,
     RO::Var: CryptographicSpongeVar<G1::ScalarField, RO, Parameters = RO::Config>,
     RO::Config: CanonicalSerialize + CanonicalDeserialize + Sync,
@@ -442,8 +442,8 @@ pub(crate) mod tests {
         G2: SWCurveConfig<BaseField = G1::ScalarField, ScalarField = G1::BaseField>,
         G1::BaseField: PrimeField + Absorb,
         G2::BaseField: PrimeField + Absorb,
-        C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>, SetupAux = ()>,
-        C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>, SetupAux = ()>,
+        C1: CommitmentScheme<Projective<G1>, SetupAux = ()>,
+        C2: CommitmentScheme<Projective<G2>, SetupAux = ()>,
     {
         let ro_config = poseidon_config();
 
@@ -486,8 +486,8 @@ pub(crate) mod tests {
         G2: SWCurveConfig<BaseField = G1::ScalarField, ScalarField = G1::BaseField>,
         G1::BaseField: PrimeField + Absorb,
         G2::BaseField: PrimeField + Absorb,
-        C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>, SetupAux = ()>,
-        C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>, SetupAux = ()>,
+        C1: CommitmentScheme<Projective<G1>, SetupAux = ()>,
+        C2: CommitmentScheme<Projective<G2>, SetupAux = ()>,
     {
         let filter = filter::Targets::new().with_target(SUPERNOVA_TARGET, tracing::Level::DEBUG);
         let _guard = tracing_subscriber::registry()

--- a/supernova/src/commitment.rs
+++ b/supernova/src/commitment.rs
@@ -1,6 +1,9 @@
-use std::ops::{Add, AddAssign, Mul, MulAssign};
+use std::{
+    fmt::Debug,
+    ops::{Add, AddAssign, Mul, MulAssign},
+};
 
-use ark_ec::PrimeGroup;
+use ark_ec::CurveGroup;
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 /// Defines basic operations on commitments.
@@ -20,34 +23,47 @@ pub trait ScalarMul<Rhs, Output = Self>: Mul<Rhs, Output = Output> + MulAssign<R
 impl<T, Rhs, Output> ScalarMul<Rhs, Output> for T where T: Mul<Rhs, Output = Output> + MulAssign<Rhs>
 {}
 
-pub trait Commitment<G: PrimeGroup>:
+pub trait Commitment<G: CurveGroup>:
     Default
+    + Debug
     + PartialEq
+    + Eq
     + Copy
     + Clone
     + Send
     + Sync
     + CommitmentOps
     + ScalarMul<G::ScalarField>
+    + Into<G>
+    + From<G>
     + CanonicalSerialize
     + CanonicalDeserialize
 {
+    /// Converts `self` into the affine representation.
+    fn into_affine(self) -> G::Affine {
+        self.into().into_affine()
+    }
 }
-impl<G: PrimeGroup, T> Commitment<G> for T where
+
+impl<G: CurveGroup, T> Commitment<G> for T where
     T: Default
+        + Debug
         + PartialEq
+        + Eq
         + Copy
         + Clone
         + Send
         + Sync
         + CommitmentOps
         + ScalarMul<G::ScalarField>
+        + Into<G>
+        + From<G>
         + CanonicalSerialize
         + CanonicalDeserialize
 {
 }
 
-pub trait CommitmentScheme<G: PrimeGroup>: Send + Sync {
+pub trait CommitmentScheme<G: CurveGroup>: Send + Sync {
     /// Commitment scheme public parameters.
     type PP: CanonicalSerialize + CanonicalDeserialize + Sync;
 

--- a/supernova/src/gadgets/multifold/mod.rs
+++ b/supernova/src/gadgets/multifold/mod.rs
@@ -11,7 +11,6 @@ use ark_r1cs_std::{
     R1CSVar, ToBitsGadget,
 };
 use ark_relations::r1cs::SynthesisError;
-use ark_std::fmt::Debug;
 
 pub(crate) mod primary;
 pub(crate) mod secondary;
@@ -39,8 +38,7 @@ where
     G1: SWCurveConfig<BaseField = G2::ScalarField, ScalarField = G2::BaseField>,
     G2: SWCurveConfig,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>> + From<Projective<G1>> + Debug + Eq,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     G1::BaseField: PrimeField,
     G2::BaseField: PrimeField,
     RO: SpongeWithGadget<G1::ScalarField>,
@@ -167,8 +165,7 @@ where
     G1: SWCurveConfig<BaseField = G2::ScalarField, ScalarField = G2::BaseField>,
     G2: SWCurveConfig,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>> + From<Projective<G1>> + Debug + Eq,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     G1::BaseField: PrimeField,
     G2::BaseField: PrimeField,
     RO: SpongeWithGadget<G1::ScalarField>,
@@ -358,8 +355,8 @@ mod tests {
     where
         G1: SWCurveConfig<BaseField = G2::ScalarField, ScalarField = G2::BaseField>,
         G2: SWCurveConfig,
-        C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>, SetupAux = ()>,
-        C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>, SetupAux = ()>,
+        C1: CommitmentScheme<Projective<G1>, SetupAux = ()>,
+        C2: CommitmentScheme<Projective<G2>, SetupAux = ()>,
         G1::BaseField: PrimeField + Absorb,
         G2::BaseField: PrimeField + Absorb,
         C1::PP: Clone,
@@ -403,7 +400,8 @@ mod tests {
             })?;
         let u_cs = primary::R1CSInstanceVar::<G1, C1>::new_input(cs.clone(), || Ok(&u))?;
 
-        let commitment_T_cs = NonNativeAffineVar::new_input(cs.clone(), || Ok(proof.commitment_T))?;
+        let commitment_T_cs =
+            NonNativeAffineVar::new_input(cs.clone(), || Ok(proof.commitment_T.into()))?;
 
         let comm_E_proof = &proof.commitment_E_proof;
         let comm_W_proof = &proof.commitment_W_proof;
@@ -464,7 +462,8 @@ mod tests {
             })?;
         let u_cs = primary::R1CSInstanceVar::<G1, C1>::new_input(cs.clone(), || Ok(&u))?;
 
-        let commitment_T_cs = NonNativeAffineVar::new_input(cs.clone(), || Ok(proof.commitment_T))?;
+        let commitment_T_cs =
+            NonNativeAffineVar::new_input(cs.clone(), || Ok(proof.commitment_T.into()))?;
 
         let comm_E_proof = &proof.commitment_E_proof;
         let comm_W_proof = &proof.commitment_W_proof;
@@ -518,8 +517,8 @@ mod tests {
     where
         G1: SWCurveConfig<BaseField = G2::ScalarField, ScalarField = G2::BaseField>,
         G2: SWCurveConfig,
-        C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>, SetupAux = ()>,
-        C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>, SetupAux = ()>,
+        C1: CommitmentScheme<Projective<G1>, SetupAux = ()>,
+        C2: CommitmentScheme<Projective<G2>, SetupAux = ()>,
         G1::BaseField: PrimeField + Absorb,
         G2::BaseField: PrimeField + Absorb,
         C1::PP: Clone,
@@ -588,13 +587,14 @@ mod tests {
                 Ok(&U2_secondary)
             })?;
         let commitment_T_secondary_cs = <ProjectiveVar<G2, FpVar<G2::BaseField>> as AllocVar<
-            C2::Commitment,
+            Projective<G2>,
             G2::BaseField,
         >>::new_input(cs.clone(), || {
-            Ok(&proof.proof_secondary.commitment_T)
+            Ok(proof.proof_secondary.commitment_T.into())
         })?;
 
-        let commitment_T_cs = NonNativeAffineVar::new_input(cs.clone(), || Ok(proof.commitment_T))?;
+        let commitment_T_cs =
+            NonNativeAffineVar::new_input(cs.clone(), || Ok(proof.commitment_T.into()))?;
 
         let comm_E_proof = &proof.commitment_E_proof;
         let comm_W_proof = &proof.commitment_W_proof;

--- a/supernova/src/gadgets/multifold/primary.rs
+++ b/supernova/src/gadgets/multifold/primary.rs
@@ -54,7 +54,6 @@ where
     G1: SWCurveConfig,
     G1::BaseField: PrimeField,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>> + From<Projective<G1>> + Eq + Debug,
 {
     type Value = R1CSInstance<G1, C1>;
 
@@ -80,7 +79,6 @@ where
     G1: SWCurveConfig,
     G1::BaseField: PrimeField,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>>,
 {
     fn new_variable<T: Borrow<R1CSInstance<G1, C1>>>(
         cs: impl Into<Namespace<G1::ScalarField>>,
@@ -120,7 +118,6 @@ where
     G1: SWCurveConfig,
     G1::BaseField: PrimeField,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>>,
 {
     fn to_sponge_bytes(&self) -> Result<Vec<UInt8<G1::ScalarField>>, SynthesisError> {
         unreachable!()
@@ -191,7 +188,6 @@ where
     G1: SWCurveConfig,
     G1::BaseField: PrimeField,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>> + From<Projective<G1>> + Eq + Debug,
 {
     type Value = RelaxedR1CSInstance<G1, C1>;
 
@@ -222,7 +218,6 @@ where
     G1: SWCurveConfig,
     G1::BaseField: PrimeField,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>>,
 {
     fn new_variable<T: Borrow<RelaxedR1CSInstance<G1, C1>>>(
         cs: impl Into<Namespace<G1::ScalarField>>,
@@ -265,7 +260,6 @@ where
     G1: SWCurveConfig,
     G1::BaseField: PrimeField,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>>,
 {
     fn to_sponge_bytes(&self) -> Result<Vec<UInt8<G1::ScalarField>>, SynthesisError> {
         unreachable!()
@@ -286,7 +280,6 @@ where
     G1: SWCurveConfig,
     G1::BaseField: PrimeField,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>>,
 {
     fn conditionally_select(
         cond: &Boolean<G1::ScalarField>,

--- a/supernova/src/gadgets/multifold/secondary.rs
+++ b/supernova/src/gadgets/multifold/secondary.rs
@@ -94,7 +94,7 @@ impl<G2, C2> R1CSVar<G2::BaseField> for R1CSInstanceVar<G2, C2>
 where
     G2: SWCurveConfig,
     G2::BaseField: PrimeField,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     type Value = R1CSInstance<G2, C2>;
 
@@ -106,7 +106,7 @@ where
     }
 
     fn value(&self) -> Result<Self::Value, SynthesisError> {
-        let commitment_W = self.commitment_W.value()?;
+        let commitment_W = self.commitment_W.value()?.into();
         let X = self.X.value()?;
         Ok(R1CSInstance { commitment_W, X })
     }
@@ -116,7 +116,7 @@ impl<G2, C2> AllocVar<R1CSInstance<G2, C2>, G2::BaseField> for R1CSInstanceVar<G
 where
     G2: SWCurveConfig,
     G2::BaseField: PrimeField,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     fn new_variable<T: Borrow<R1CSInstance<G2, C2>>>(
         cs: impl Into<Namespace<G2::BaseField>>,
@@ -133,7 +133,7 @@ where
 
         let commitment_W = ProjectiveVar::<G2, FpVar<G2::BaseField>>::new_variable(
             cs.clone(),
-            || Ok(r1cs.borrow().commitment_W),
+            || Ok(r1cs.borrow().commitment_W.into()),
             mode,
         )?;
         let alloc_X = X[1..]
@@ -156,7 +156,7 @@ impl<G2, C2> AbsorbGadget<G2::BaseField> for R1CSInstanceVar<G2, C2>
 where
     G2: SWCurveConfig,
     G2::BaseField: PrimeField,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     fn to_sponge_bytes(&self) -> Result<Vec<UInt8<G2::BaseField>>, SynthesisError> {
         unreachable!()
@@ -225,7 +225,7 @@ impl<G2, C2> R1CSVar<G2::BaseField> for RelaxedR1CSInstanceVar<G2, C2>
 where
     G2: SWCurveConfig,
     G2::BaseField: PrimeField,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     type Value = RelaxedR1CSInstance<G2, C2>;
 
@@ -238,8 +238,8 @@ where
     }
 
     fn value(&self) -> Result<Self::Value, SynthesisError> {
-        let commitment_W = self.commitment_W.value()?;
-        let commitment_E = self.commitment_E.value()?;
+        let commitment_W = self.commitment_W.value()?.into();
+        let commitment_E = self.commitment_E.value()?.into();
         let X = self.X.value()?;
 
         Ok(RelaxedR1CSInstance {
@@ -254,7 +254,7 @@ impl<G2, C2> AllocVar<RelaxedR1CSInstance<G2, C2>, G2::BaseField> for RelaxedR1C
 where
     G2: SWCurveConfig,
     G2::BaseField: PrimeField,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     fn new_variable<T: Borrow<RelaxedR1CSInstance<G2, C2>>>(
         cs: impl Into<Namespace<G2::BaseField>>,
@@ -269,12 +269,12 @@ where
 
         let commitment_W = ProjectiveVar::<G2, FpVar<G2::BaseField>>::new_variable(
             cs.clone(),
-            || Ok(r1cs.borrow().commitment_W),
+            || Ok(r1cs.borrow().commitment_W.into()),
             mode,
         )?;
         let commitment_E = ProjectiveVar::<G2, FpVar<G2::BaseField>>::new_variable(
             cs.clone(),
-            || Ok(r1cs.borrow().commitment_E),
+            || Ok(r1cs.borrow().commitment_E.into()),
             mode,
         )?;
 
@@ -302,7 +302,7 @@ impl<G2, C2> AbsorbGadget<G2::BaseField> for RelaxedR1CSInstanceVar<G2, C2>
 where
     G2: SWCurveConfig,
     G2::BaseField: PrimeField,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     fn to_sponge_bytes(&self) -> Result<Vec<UInt8<G2::BaseField>>, SynthesisError> {
         unreachable!()
@@ -328,7 +328,7 @@ impl<G2, C2> CondSelectGadget<G2::BaseField> for RelaxedR1CSInstanceVar<G2, C2>
 where
     G2: SWCurveConfig,
     G2::BaseField: PrimeField,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     fn conditionally_select(
         cond: &Boolean<G2::BaseField>,
@@ -358,7 +358,7 @@ impl<G2, C2> RelaxedR1CSInstanceVar<G2, C2>
 where
     G2: SWCurveConfig,
     G2::BaseField: PrimeField,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     pub(super) fn fold(
         &self,
@@ -411,7 +411,7 @@ pub struct ProofVar<G2, C2>
 where
     G2: SWCurveConfig,
     G2::BaseField: PrimeField,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     pub(crate) U: R1CSInstanceVar<G2, C2>,
     pub(crate) commitment_T: ProjectiveVar<G2, FpVar<G2::BaseField>>,
@@ -421,7 +421,7 @@ impl<G2, C2> AllocVar<Proof<G2, C2>, G2::BaseField> for ProofVar<G2, C2>
 where
     G2: SWCurveConfig,
     G2::BaseField: PrimeField,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     fn new_variable<T: Borrow<Proof<G2, C2>>>(
         cs: impl Into<Namespace<G2::BaseField>>,
@@ -443,10 +443,10 @@ where
         Ok(Self {
             U: R1CSInstanceVar::new_variable(cs.clone(), || Ok(&U), mode)?,
             commitment_T: <ProjectiveVar<G2, FpVar<G2::BaseField>> as AllocVar<
-                C2::Commitment,
+                Projective<G2>,
                 G2::BaseField,
             >>::new_variable(
-                cs.clone(), || Ok(&proof.borrow().commitment_T), mode
+                cs.clone(), || Ok(proof.borrow().commitment_T.into()), mode
             )?,
         })
     }
@@ -477,7 +477,7 @@ impl<G2, C2> R1CSInstanceVar<G2, C2>
 where
     G2: SWCurveConfig,
     G2::BaseField: PrimeField,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     /// Parses `r, g_out` from the public input of the secondary circuit.
     pub fn parse_secondary_io<G1>(

--- a/supernova/src/multifold/nimfs/mod.rs
+++ b/supernova/src/multifold/nimfs/mod.rs
@@ -1,15 +1,12 @@
 use ark_crypto_primitives::sponge::{Absorb, CryptographicSponge};
-use ark_ec::{
-    short_weierstrass::{Projective, SWCurveConfig},
-    CurveGroup,
-};
+use ark_ec::short_weierstrass::{Projective, SWCurveConfig};
 use ark_ff::PrimeField;
 use ark_std::Zero;
 
 use super::{secondary, Error};
 use crate::{
     absorb::CryptographicSpongeExt,
-    commitment::CommitmentScheme,
+    commitment::{Commitment, CommitmentScheme},
     r1cs,
     utils::{cast_field_element, cast_field_element_unique},
 };
@@ -29,11 +26,9 @@ pub struct NIMFSProof<
     G1: SWCurveConfig,
     G2: SWCurveConfig,
     C1: CommitmentScheme<Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     RO,
-> where
-    C1::Commitment: Into<Projective<G1>>,
-{
+> {
     pub(crate) commitment_T: C1::Commitment,
     pub(crate) commitment_E_proof: [secondary::Proof<G2, C2>; 2],
     pub(crate) commitment_W_proof: secondary::Proof<G2, C2>,
@@ -45,8 +40,7 @@ where
     G1: SWCurveConfig,
     G2: SWCurveConfig,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -63,8 +57,7 @@ where
     G1: SWCurveConfig,
     G2: SWCurveConfig,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>> + From<Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     G1::BaseField: PrimeField,
 {
     fn default() -> Self {
@@ -82,8 +75,7 @@ where
     G1: SWCurveConfig<BaseField = G2::ScalarField, ScalarField = G2::BaseField>,
     G2: SWCurveConfig,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>> + From<Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     G1::BaseField: PrimeField + Absorb,
     G2::BaseField: PrimeField + Absorb,
     RO: CryptographicSponge,
@@ -204,6 +196,7 @@ where
 
         Ok((proof, (folded_U, folded_W), (U_secondary, W_secondary)))
     }
+
     #[cfg(any(test, feature = "spartan"))]
     pub fn verify(
         &self,
@@ -296,8 +289,6 @@ mod tests {
     use ark_crypto_primitives::sponge::poseidon::PoseidonSponge;
     use ark_ff::Field;
 
-    use std::fmt;
-
     #[test]
     fn prove_verify() {
         prove_verify_with_cycle::<
@@ -313,10 +304,8 @@ mod tests {
     where
         G1: SWCurveConfig<BaseField = G2::ScalarField, ScalarField = G2::BaseField>,
         G2: SWCurveConfig,
-        C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>, SetupAux = ()>
-            + fmt::Debug,
-        C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>, SetupAux = ()>
-            + fmt::Debug,
+        C1: CommitmentScheme<Projective<G1>, SetupAux = ()>,
+        C2: CommitmentScheme<Projective<G2>, SetupAux = ()>,
         G1::BaseField: PrimeField + Absorb,
         G2::BaseField: PrimeField + Absorb,
         C1::PP: Clone,

--- a/supernova/src/multifold/nimfs/relaxed.rs
+++ b/supernova/src/multifold/nimfs/relaxed.rs
@@ -1,13 +1,10 @@
 use ark_crypto_primitives::sponge::{Absorb, CryptographicSponge};
-use ark_ec::{
-    short_weierstrass::{Projective, SWCurveConfig},
-    CurveGroup,
-};
+use ark_ec::short_weierstrass::{Projective, SWCurveConfig};
 use ark_ff::{Field, PrimeField};
 
 use crate::{
     absorb::CryptographicSpongeExt,
-    commitment::CommitmentScheme,
+    commitment::{Commitment, CommitmentScheme},
     multifold::secondary,
     r1cs,
     utils::{cast_field_element, cast_field_element_unique},
@@ -23,8 +20,7 @@ where
     G1: SWCurveConfig<BaseField = G2::ScalarField, ScalarField = G2::BaseField>,
     G2: SWCurveConfig,
     C1: CommitmentScheme<Projective<G1>>,
-    C1::Commitment: Into<Projective<G1>> + From<Projective<G1>>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
     G1::BaseField: PrimeField + Absorb,
     G2::BaseField: PrimeField + Absorb,
     RO: CryptographicSponge,
@@ -325,8 +321,6 @@ mod tests {
     use ark_ff::Field;
     use ark_std::{rand::Rng, UniformRand, Zero};
 
-    use std::fmt;
-
     #[test]
     fn prove_verify() {
         prove_verify_with_cycle::<
@@ -342,10 +336,8 @@ mod tests {
     where
         G1: SWCurveConfig<BaseField = G2::ScalarField, ScalarField = G2::BaseField>,
         G2: SWCurveConfig,
-        C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>, SetupAux = ()>
-            + fmt::Debug,
-        C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>, SetupAux = ()>
-            + fmt::Debug,
+        C1: CommitmentScheme<Projective<G1>, SetupAux = ()>,
+        C2: CommitmentScheme<Projective<G2>, SetupAux = ()>,
         G1::BaseField: PrimeField + Absorb,
         G2::BaseField: PrimeField + Absorb,
         C1::PP: Clone,
@@ -410,9 +402,8 @@ mod tests {
     where
         G1: SWCurveConfig<BaseField = G2::ScalarField, ScalarField = G2::BaseField>,
         G2: SWCurveConfig,
-        C1: CommitmentScheme<Projective<G1>, Commitment = Projective<G1>, SetupAux = ()>
-            + fmt::Debug,
-        C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>> + fmt::Debug,
+        C1: CommitmentScheme<Projective<G1>, SetupAux = ()>,
+        C2: CommitmentScheme<Projective<G2>>,
         G1::BaseField: PrimeField + Absorb,
         G2::BaseField: PrimeField + Absorb,
         C1::PP: Clone,
@@ -461,7 +452,7 @@ mod tests {
                 (&U2_secondary, &W2_secondary),
             )?;
 
-        assert!(!U.commitment_E.is_zero());
+        assert!(!U.commitment_E.into().is_zero());
         Ok(((U, W), (U_secondary, W_secondary)))
     }
 }

--- a/supernova/src/multifold/secondary/mod.rs
+++ b/supernova/src/multifold/secondary/mod.rs
@@ -101,7 +101,7 @@ where
     G1: SWCurveConfig,
     G1::BaseField: PrimeField,
     G2: SWCurveConfig<BaseField = G1::ScalarField, ScalarField = G1::BaseField>,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     let cs = ConstraintSystem::<G1::BaseField>::new_ref();
     cs.set_mode(SynthesisMode::Prove {
@@ -128,10 +128,7 @@ where
 }
 
 /// Folding scheme proof for a secondary circuit.
-pub struct Proof<
-    G2: SWCurveConfig,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
-> {
+pub struct Proof<G2: SWCurveConfig, C2: CommitmentScheme<Projective<G2>>> {
     pub(crate) U: R1CSInstance<G2, C2>,
     pub(crate) commitment_T: C2::Commitment,
 }
@@ -139,7 +136,7 @@ pub struct Proof<
 impl<G2, C2> Clone for Proof<G2, C2>
 where
     G2: SWCurveConfig,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -152,16 +149,16 @@ where
 impl<G2, C2> Default for Proof<G2, C2>
 where
     G2: SWCurveConfig,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     fn default() -> Self {
         let U = R1CSInstance {
-            commitment_W: Projective::zero(),
+            commitment_W: Projective::zero().into(),
             X: vec![G2::ScalarField::ZERO; SECONDARY_NUM_IO],
         };
         Self {
             U,
-            commitment_T: Projective::zero(),
+            commitment_T: Projective::zero().into(),
         }
     }
 }
@@ -185,7 +182,7 @@ macro_rules! parse_projective {
 impl<G2, C2> R1CSInstance<G2, C2>
 where
     G2: SWCurveConfig,
-    C2: CommitmentScheme<Projective<G2>, Commitment = Projective<G2>>,
+    C2: CommitmentScheme<Projective<G2>>,
 {
     #[cfg(any(test, feature = "spartan"))]
     pub(crate) fn parse_secondary_io<G1>(&self) -> Option<Circuit<G1>>

--- a/supernova/src/nifs.rs
+++ b/supernova/src/nifs.rs
@@ -1,23 +1,23 @@
 use std::marker::PhantomData;
 
 use ark_crypto_primitives::sponge::{Absorb, CryptographicSponge, FieldElementSize};
-use ark_ec::{CurveGroup, PrimeGroup};
+use ark_ec::CurveGroup;
 use ark_ff::{PrimeField, ToConstraintField};
 
 use super::{
     absorb::{AbsorbNonNative, CryptographicSpongeExt},
-    commitment::CommitmentScheme,
+    commitment::{Commitment, CommitmentScheme},
     r1cs::{self, R1CSShape, RelaxedR1CSInstance, RelaxedR1CSWitness},
 };
 
 pub const SQUEEZE_ELEMENTS_BIT_SIZE: FieldElementSize = FieldElementSize::Truncated(127);
 
-pub struct NIFSProof<G: PrimeGroup, C: CommitmentScheme<G>, RO> {
+pub struct NIFSProof<G: CurveGroup, C: CommitmentScheme<G>, RO> {
     pub(crate) commitment_T: C::Commitment,
     _random_oracle: PhantomData<RO>,
 }
 
-impl<G: PrimeGroup, C: CommitmentScheme<G>, RO> Default for NIFSProof<G, C, RO> {
+impl<G: CurveGroup, C: CommitmentScheme<G>, RO> Default for NIFSProof<G, C, RO> {
     fn default() -> Self {
         Self {
             commitment_T: Default::default(),
@@ -26,7 +26,7 @@ impl<G: PrimeGroup, C: CommitmentScheme<G>, RO> Default for NIFSProof<G, C, RO> 
     }
 }
 
-impl<G: PrimeGroup, C: CommitmentScheme<G>, RO> Clone for NIFSProof<G, C, RO> {
+impl<G: CurveGroup, C: CommitmentScheme<G>, RO> Clone for NIFSProof<G, C, RO> {
     fn clone(&self) -> Self {
         Self {
             commitment_T: self.commitment_T,
@@ -38,7 +38,7 @@ impl<G: PrimeGroup, C: CommitmentScheme<G>, RO> Clone for NIFSProof<G, C, RO> {
 impl<G, C, RO> NIFSProof<G, C, RO>
 where
     G: CurveGroup + AbsorbNonNative<G::ScalarField>,
-    C: CommitmentScheme<G, Commitment = G>,
+    C: CommitmentScheme<G>,
     G::BaseField: PrimeField + Absorb,
     G::ScalarField: Absorb,
     G::Affine: Absorb + ToConstraintField<G::BaseField>,
@@ -114,7 +114,7 @@ pub(crate) mod tests {
         G: SWCurveConfig,
         G::BaseField: PrimeField + Absorb,
         G::ScalarField: Absorb,
-        C: CommitmentScheme<Projective<G>, Commitment = Projective<G>, SetupAux = ()>,
+        C: CommitmentScheme<Projective<G>, SetupAux = ()>,
         C::PP: Clone,
     {
         let config = poseidon_config::<G::BaseField>();

--- a/supernova/src/provider/pedersen.rs
+++ b/supernova/src/provider/pedersen.rs
@@ -1,7 +1,7 @@
 use std::marker::PhantomData;
 
 use crate::{commitment::CommitmentScheme, LOG_TARGET};
-use ark_ec::{ScalarMul, VariableBaseMSM};
+use ark_ec::{CurveGroup, ScalarMul, VariableBaseMSM};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
 #[derive(Debug)]
@@ -9,7 +9,7 @@ pub struct PedersenCommitment<G>(PhantomData<G>);
 
 impl<G> CommitmentScheme<G> for PedersenCommitment<G>
 where
-    G: VariableBaseMSM,
+    G: CurveGroup,
     G::MulBase: CanonicalSerialize + CanonicalDeserialize,
 {
     type PP = Vec<G::MulBase>;


### PR DESCRIPTION
Basically, get rid of `, Commitment = Projective<G>` bound everywhere + move `Into + From` into the `Commitment` trait.