### PR TITLE
supernova-benches: fix dependency path

### DIFF
--- a/supernova-benches/Cargo.toml
+++ b/supernova-benches/Cargo.toml
@@ -15,7 +15,7 @@ ark-vesta = "0.4.0"
 criterion = "0.5"
 pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
 
-supernova = { path = "..", default-features = false }
+supernova = { path = "../supernova", default-features = false }
 
 [features]
 default = ["parallel"]


### PR DESCRIPTION
Follow-up for https://github.com/nexus-xyz/nexus-zkvm/pull/44 to make bench build