### PR TITLE
Add summary of changes from `ark_spartan` to readme

### DIFF
--- a/spartan/README.md
+++ b/spartan/README.md
@@ -1,4 +1,4 @@
-**NOTE:** 
+**NOTE:**
 This crate is a fork from the [Spartan implementation in
 arkworks](https://github.com/arkworks-rs/spartan), which
 is itself a fork of
@@ -7,16 +7,16 @@ Arkworks backend. The primary changes are:
 - implementation of the "modified Spartan for committed relaxed r1cs"
   construction from the [Nova paper](https://eprint.iacr.org/2021/370). Compare
   to [Microsoft's Nova
-  implementation](https://github.com/microsoft/Nova/tree/main/src/spartan). 
+  implementation](https://github.com/microsoft/Nova/tree/main/src/spartan).
 - introduction of a generic interface for
   [multilinear polynomial
   commitments](https://github.com/nexus-xyz/nexus-zkvm/tree/main/spartan/src/polycommitments)
   and modification of the Spartan code to be generic over this interface.
   - this is adapted from the [Arkworks `poly-commit`
     crate](https://github.com/arkworks-rs/poly-commit), but simplified and
-    specialized to our context. 
+    specialized to our context.
 - implementation of the [Zeromorph multilinear polynomial commitment
-  scheme](https://eprint.iacr.org/2023/917). 
+  scheme](https://eprint.iacr.org/2023/917).
 
 ----------------------------------------------------------------
 # Spartan: High-speed zkSNARKs without trusted setup

--- a/spartan/README.md
+++ b/spartan/README.md
@@ -1,3 +1,24 @@
+**NOTE:** 
+This crate is a fork from the [Spartan implementation in
+arkworks](https://github.com/arkworks-rs/spartan), which
+is itself a fork of
+[Microsoft's implementation](https://github.com/microsoft/Spartan) based on the
+Arkworks backend. The primary changes are:
+- implementation of the "modified Spartan for committed relaxed r1cs"
+  construction from the [Nova paper](https://eprint.iacr.org/2021/370). Compare
+  to [Microsoft's Nova
+  implementation](https://github.com/microsoft/Nova/tree/main/src/spartan). 
+- introduction of a generic interface for
+  [multilinear polynomial
+  commitments](https://github.com/nexus-xyz/nexus-zkvm/tree/main/spartan/src/polycommitments)
+  and modification of the Spartan code to be generic over this interface.
+  - this is adapted from the [Arkworks `poly-commit`
+    crate](https://github.com/arkworks-rs/poly-commit), but simplified and
+    specialized to our context. 
+- implementation of the [Zeromorph multilinear polynomial commitment
+  scheme](https://eprint.iacr.org/2023/917). 
+
+----------------------------------------------------------------
 # Spartan: High-speed zkSNARKs without trusted setup
 
 ![Rust](https://github.com/microsoft/Spartan/workflows/Rust/badge.svg)


### PR DESCRIPTION
- add basic setup flow using SRS
- merge with main
- some small fixes to bugs in the compression module from recent PRs
- spartan integration fixes
- tests for srs generation
- sets default srs size to 19
- use `deserialize_compressed_unchecked`
- remove unnecessary blinding factor from SRS generation
- fix
- adds SRS to git lfs
- testing proof deserialization
- proofs save and verify
- removed cargo.lock
- todo: merge dorebell onto this
- fixed merge mistakes
- reads proof and compresses. key not yet saved to file
- added back cargo.lock
- moved the compression cli into prover crate
- formatting
- remove whitespace
- added com option to prove
- updated local prove
- todo:save key and proof to file
- derive CanonicalSerialize+CanonicalDeserialize for Spartan types
- add options to save and load spartan key from file
- save compressed proof to file, implement arkworks serialization
- update README.md
