### PR TITLE
Update arkworks dependencies for improved deserialization of group elements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 [[package]]
 name = "ark-ec"
 version = "0.4.2"
-source = "git+https://github.com/arkworks-rs/algebra/?rev=c92be0e#c92be0e8815875460e736086a6b02fed9e4273ff"
+source = "git+https://github.com/arkworks-rs/algebra/?rev=2a80c54#2a80c54687582f49cbbe9a27b94071e1a500f056"
 dependencies = [
  "ark-ff",
  "ark-poly",
@@ -165,7 +165,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "hashbrown",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "num-bigint",
  "num-traits",
  "rayon",
@@ -175,42 +175,42 @@ dependencies = [
 [[package]]
 name = "ark-ff"
 version = "0.4.2"
-source = "git+https://github.com/arkworks-rs/algebra/?rev=c92be0e#c92be0e8815875460e736086a6b02fed9e4273ff"
+source = "git+https://github.com/arkworks-rs/algebra/?rev=2a80c54#2a80c54687582f49cbbe9a27b94071e1a500f056"
 dependencies = [
  "ark-ff-asm",
  "ark-ff-macros",
  "ark-serialize",
  "ark-std",
+ "arrayvec",
  "derivative",
  "digest 0.10.7",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "num-bigint",
  "num-traits",
  "paste",
  "rayon",
- "rustc_version",
  "zeroize",
 ]
 
 [[package]]
 name = "ark-ff-asm"
 version = "0.4.2"
-source = "git+https://github.com/arkworks-rs/algebra/?rev=c92be0e#c92be0e8815875460e736086a6b02fed9e4273ff"
+source = "git+https://github.com/arkworks-rs/algebra/?rev=2a80c54#2a80c54687582f49cbbe9a27b94071e1a500f056"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.50",
 ]
 
 [[package]]
 name = "ark-ff-macros"
 version = "0.4.2"
-source = "git+https://github.com/arkworks-rs/algebra/?rev=c92be0e#c92be0e8815875460e736086a6b02fed9e4273ff"
+source = "git+https://github.com/arkworks-rs/algebra/?rev=2a80c54#2a80c54687582f49cbbe9a27b94071e1a500f056"
 dependencies = [
  "num-bigint",
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "ark-poly"
 version = "0.4.2"
-source = "git+https://github.com/arkworks-rs/algebra/?rev=c92be0e#c92be0e8815875460e736086a6b02fed9e4273ff"
+source = "git+https://github.com/arkworks-rs/algebra/?rev=2a80c54#2a80c54687582f49cbbe9a27b94071e1a500f056"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -250,7 +250,7 @@ dependencies = [
 [[package]]
 name = "ark-poly-commit"
 version = "0.4.0"
-source = "git+https://github.com/arkworks-rs/poly-commit/?rev=c724fa6#c724fa666e935bbba8db5a1421603bab542e15ab"
+source = "git+https://github.com/arkworks-rs/poly-commit/?rev=12f5529#12f5529c9ca609d07dd4683fcd1e196bc375eb0d"
 dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
@@ -295,7 +295,7 @@ dependencies = [
 [[package]]
 name = "ark-serialize"
 version = "0.4.2"
-source = "git+https://github.com/arkworks-rs/algebra/?rev=c92be0e#c92be0e8815875460e736086a6b02fed9e4273ff"
+source = "git+https://github.com/arkworks-rs/algebra/?rev=2a80c54#2a80c54687582f49cbbe9a27b94071e1a500f056"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
@@ -306,11 +306,11 @@ dependencies = [
 [[package]]
 name = "ark-serialize-derive"
 version = "0.4.2"
-source = "git+https://github.com/arkworks-rs/algebra/?rev=c92be0e#c92be0e8815875460e736086a6b02fed9e4273ff"
+source = "git+https://github.com/arkworks-rs/algebra/?rev=2a80c54#2a80c54687582f49cbbe9a27b94071e1a500f056"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.50",
 ]
 
 [[package]]
@@ -367,7 +367,7 @@ dependencies = [
 [[package]]
 name = "ark-test-curves"
 version = "0.4.2"
-source = "git+https://github.com/arkworks-rs/algebra/?rev=c92be0e#c92be0e8815875460e736086a6b02fed9e4273ff"
+source = "git+https://github.com/arkworks-rs/algebra/?rev=2a80c54#2a80c54687582f49cbbe9a27b94071e1a500f056"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -1445,9 +1445,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,12 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 elf = { version = "0.7", default-features = false, features = ["std"] }
 
-ark-crypto-primitives = { version = "0.4.0", features = ["r1cs", "sponge", "crh", "merkle_tree"] }
+ark-crypto-primitives = { version = "0.4.0", features = [
+    "r1cs",
+    "sponge",
+    "crh",
+    "merkle_tree",
+] }
 ark-std = "0.4.0"
 
 ark-relations = { version = "0.4.0" }
@@ -65,19 +70,19 @@ ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitive
 
 ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std/", rev = "2ca3bd7" }
 
-ark-ff          = { git = "https://github.com/arkworks-rs/algebra/", rev = "c92be0e" }
-ark-ec          = { git = "https://github.com/arkworks-rs/algebra/", rev = "c92be0e" }
-ark-serialize   = { git = "https://github.com/arkworks-rs/algebra/", rev = "c92be0e" }
-ark-poly        = { git = "https://github.com/arkworks-rs/algebra/", rev = "c92be0e" }
-ark-test-curves = { git = "https://github.com/arkworks-rs/algebra/", rev = "c92be0e" }
+ark-ff = { git = "https://github.com/arkworks-rs/algebra/", rev = "2a80c54" }
+ark-ec = { git = "https://github.com/arkworks-rs/algebra/", rev = "2a80c54" }
+ark-serialize = { git = "https://github.com/arkworks-rs/algebra/", rev = "2a80c54" }
+ark-poly = { git = "https://github.com/arkworks-rs/algebra/", rev = "2a80c54" }
+ark-test-curves = { git = "https://github.com/arkworks-rs/algebra/", rev = "2a80c54" }
 
-ark-poly-commit = { git = "https://github.com/arkworks-rs/poly-commit/", rev = "c724fa6" }
+ark-poly-commit = { git = "https://github.com/arkworks-rs/poly-commit/", rev = "12f5529" }
 
 # note bls is using a different commit from the other curves
-ark-bn254     = { git = "https://github.com/arkworks-rs/curves/", rev = "8c0256a" }
-ark-grumpkin  = { git = "https://github.com/arkworks-rs/curves/", rev = "8c0256a" }
-ark-pallas    = { git = "https://github.com/arkworks-rs/curves/", rev = "8c0256a" }
-ark-vesta     = { git = "https://github.com/arkworks-rs/curves/", rev = "8c0256a" }
+ark-bn254 = { git = "https://github.com/arkworks-rs/curves/", rev = "8c0256a" }
+ark-grumpkin = { git = "https://github.com/arkworks-rs/curves/", rev = "8c0256a" }
+ark-pallas = { git = "https://github.com/arkworks-rs/curves/", rev = "8c0256a" }
+ark-vesta = { git = "https://github.com/arkworks-rs/curves/", rev = "8c0256a" }
 ark-bls12-381 = { git = "https://github.com/arkworks-rs/curves/", rev = "3fded1f" }
 
 [profile.release]

--- a/nova/src/folding/hypernova/ml_sumcheck/data_structures.rs
+++ b/nova/src/folding/hypernova/ml_sumcheck/data_structures.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use ark_crypto_primitives::sponge::Absorb;
 use ark_ff::{Field, PrimeField};
-use ark_poly::{DenseMultilinearExtension, MultilinearExtension};
+use ark_poly::{DenseMultilinearExtension, MultilinearExtension, Polynomial};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::{cmp::max, rc::Rc};
 
@@ -118,7 +118,7 @@ impl<F: Field> ListOfProductsOfPolynomials<F> {
             .map(|(c, p)| {
                 *c * p
                     .iter()
-                    .map(|&i| self.flattened_ml_extensions[i].evaluate(point).unwrap())
+                    .map(|&i| self.flattened_ml_extensions[i].evaluate(&point.to_vec()))
                     .product::<F>()
             })
             .sum()

--- a/spartan/src/polycommitments/zeromorph/mod.rs
+++ b/spartan/src/polycommitments/zeromorph/mod.rs
@@ -1,5 +1,4 @@
-use ark_ec::{pairing::Pairing, scalar_mul::fixed_base::FixedBase, AffineRepr, CurveGroup};
-use ark_ff::PrimeField;
+use ark_ec::{pairing::Pairing, AffineRepr, CurveGroup, ScalarMul};
 use ark_poly::{univariate::DensePolynomial as DenseUnivarPolynomial, DenseUVPolynomial};
 use ark_poly_commit::{
   error::Error,
@@ -7,8 +6,8 @@ use ark_poly_commit::{
   PCUniversalParams,
 };
 use ark_std::{
-  collections::BTreeMap, end_timer, marker::PhantomData, ops::Mul, rand::RngCore, start_timer,
-  vec::Vec, One, UniformRand, Zero,
+  end_timer, marker::PhantomData, ops::Mul, rand::RngCore, start_timer, vec::Vec, One, UniformRand,
+  Zero,
 };
 use merlin::Transcript;
 
@@ -275,34 +274,19 @@ where
       ));
       let beta = E::ScalarField::rand(rng);
       let g = E::G1::rand(rng);
-      let gamma_g = E::G1::rand(rng);
       let h = E::G2::rand(rng);
+      // powers_of_beta = [1, b, ..., b^(max_degree + 1)], len = max_degree + 2
       let mut powers_of_beta = vec![E::ScalarField::one()];
 
       let mut cur = beta;
-      for _ in 0..max_degree {
+      for _ in 0..=max_degree {
         powers_of_beta.push(cur);
         cur *= &beta;
       }
 
-      let window_size = FixedBase::get_mul_window_size(max_degree + 1);
-
-      let scalar_bits = E::ScalarField::MODULUS_BIT_SIZE as usize;
       let g_time = start_timer!(|| "Generating powers of G");
-      let g_table = FixedBase::get_window_table(scalar_bits, window_size, g);
-      let powers_of_g =
-        FixedBase::msm::<E::G1>(scalar_bits, window_size, &g_table, &powers_of_beta);
+      let powers_of_g = g.batch_mul(&powers_of_beta[0..max_degree + 1]);
       end_timer!(g_time);
-      let gamma_g_time = start_timer!(|| "Generating powers of gamma * G");
-      let gamma_g_table = FixedBase::get_window_table(scalar_bits, window_size, gamma_g);
-      let mut powers_of_gamma_g =
-        FixedBase::msm::<E::G1>(scalar_bits, window_size, &gamma_g_table, &powers_of_beta);
-      // Add an additional power of gamma_g, because we want to be able to support
-      // up to D queries.
-      powers_of_gamma_g.push(powers_of_gamma_g.last().unwrap().mul(&beta));
-      end_timer!(gamma_g_time);
-
-      let powers_of_g = E::G1::normalize_batch(&powers_of_g);
 
       let powers_of_h_time = start_timer!(|| "Generating powers of h in G2");
       let shift_powers_of_tau_h = {
@@ -311,17 +295,10 @@ where
           // powers_of_beta[k] = beta^k and N_max = max_degree + 1; we want shift_powers_of_beta[n] = beta^(N_max - 2^n + 1)
           shift_powers_of_beta.push(powers_of_beta[max_degree + 1 - Math::pow2(n) + 1]);
         }
-        let window_size = FixedBase::get_mul_window_size(max_num_poly_vars + 1);
-        let h_table = FixedBase::get_window_table(scalar_bits, window_size, h);
-        let powers_of_h =
-          FixedBase::msm::<E::G2>(scalar_bits, window_size, &h_table, &shift_powers_of_beta);
-
-        let affines = E::G2::normalize_batch(&powers_of_h);
-        let mut affines_map = BTreeMap::new();
-        affines.into_iter().enumerate().for_each(|(i, a)| {
-          affines_map.insert(i, a);
-        });
-        affines_map
+        h.batch_mul(&shift_powers_of_beta)
+          .into_iter()
+          .enumerate()
+          .collect()
       };
 
       end_timer!(powers_of_h_time);


### PR DESCRIPTION
Integrates Arkworks [PR #771](https://github.com/arkworks-rs/algebra/pull/771), which omits an expensive and unnecessary check when deserializing group elements. This check ensures that a curve point is in the correct prime-order subgroup by multiplying it by the scalar field's modulus. This is not needed when using prime-order elliptic curve groups, as is the case for `bn254`, `grumpkin`, and any curve that occurs as part of a cycle. 