### PR TITLE
add an example for `nexus-prover`

### DIFF
--- a/prover/Cargo.toml
+++ b/prover/Cargo.toml
@@ -35,6 +35,10 @@ ark-serialize.workspace = true
 ark-bn254.workspace = true
 ark-grumpkin.workspace = true
 
+[dev-dependencies]
+anyhow = "1.0"
+nexus-config = { path = "../config" }
+
 [features]
 default = ["parallel", "snmalloc"]
 parallel = [
@@ -46,3 +50,5 @@ parallel = [
    "nexus-nova/parallel",
 ]
 snmalloc = ["snmalloc-rs"]
+# TODO: disable superconsole if not enabled
+verbose = []

--- a/prover/examples/prove.rs
+++ b/prover/examples/prove.rs
@@ -1,0 +1,41 @@
+//! Example of using `nexus-prover` API.
+//! Run with `cargo run --release --example prove`.
+
+use nexus_config::{vm::NovaImpl, VmConfig};
+use nexus_vm::riscv::VMOpts;
+
+use tracing::level_filters::LevelFilter;
+use tracing_subscriber::EnvFilter;
+
+const CONFIG: VmConfig = VmConfig { k: 16, nova_impl: NovaImpl::Sequential };
+
+fn main() -> anyhow::Result<()> {
+    let filter = EnvFilter::builder()
+        .with_default_directive(LevelFilter::DEBUG.into())
+        .from_env()
+        .unwrap()
+        .add_directive("r1cs=off".parse().unwrap());
+    tracing_subscriber::fmt()
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
+        .with_env_filter(filter)
+        .init();
+
+    tracing::info!("Setting up public parameters...");
+    let public_params = nexus_prover::pp::gen_vm_pp(CONFIG.k)?;
+
+    // Run the program.
+    let vm_opts = VMOpts {
+        k: CONFIG.k,
+        nop: Some(10),
+        ..Default::default()
+    };
+    let trace = nexus_prover::run(&vm_opts, matches!(CONFIG.nova_impl, NovaImpl::Parallel))?;
+
+    tracing::info!("Proving execution trace...");
+    let proof = nexus_prover::prove_seq(&public_params, trace)?;
+
+    tracing::info!("Verifying proof...");
+    proof.verify(&public_params, proof.step_num() as _)?;
+
+    Ok(())
+}

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -16,6 +16,11 @@ use crate::{
     types::{IVCProof, PCDNode, ParPP, SeqPP},
 };
 
+#[cfg(feature = "verbose")]
+const TERMINAL_MODE: nexus_tui::Mode = nexus_tui::Mode::Enabled;
+#[cfg(not(feature = "verbose"))]
+const TERMINAL_MODE: nexus_tui::Mode = nexus_tui::Mode::Disabled;
+
 const LOG_TARGET: &str = "nexus-prover";
 
 fn estimate_size(tr: &Trace) -> usize {
@@ -51,7 +56,7 @@ pub fn prove_seq(pp: &SeqPP, trace: Trace) -> Result<IVCProof, ProofError> {
 
     let num_steps = tr.steps();
 
-    let mut term = nexus_tui::TerminalHandle::new();
+    let mut term = nexus_tui::TerminalHandle::new(TERMINAL_MODE);
     let mut term_ctx = term
         .context("Computing")
         .on_step(|step| format!("step {step}"))
@@ -96,7 +101,7 @@ pub fn prove_par(pp: ParPP, trace: Trace) -> Result<PCDNode, ProofError> {
         format!("{step_type} {step}")
     };
 
-    let mut term = nexus_tui::TerminalHandle::new();
+    let mut term = nexus_tui::TerminalHandle::new(TERMINAL_MODE);
     let mut term_ctx = term
         .context("Computing")
         .on_step(on_step)

--- a/prover/src/pp.rs
+++ b/prover/src/pp.rs
@@ -6,7 +6,7 @@ pub use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use crate::circuit::{nop_circuit, Tr};
 use crate::error::*;
 use crate::types::*;
-use crate::LOG_TARGET;
+use crate::{LOG_TARGET, TERMINAL_MODE};
 
 pub fn gen_pp<SP>(circuit: &SC) -> Result<PP<SP>, ProofError>
 where
@@ -69,7 +69,7 @@ pub fn gen_to_file(k: usize, par: bool, pp_file: &str) -> Result<(), ProofError>
         path = ?pp_file,
         "Generating public parameters",
     );
-    let mut term = nexus_tui::TerminalHandle::new();
+    let mut term = nexus_tui::TerminalHandle::new(TERMINAL_MODE);
     let mut term_ctx = term
         .context("Setting up")
         .on_step(|_step| "public parameters".into());
@@ -90,7 +90,7 @@ pub fn gen_or_load<SP>(gen: bool, k: usize, pp_file: &str) -> Result<PP<SP>, Pro
 where
     SP: SetupParams<G1, G2, C1, C2, RO, Tr> + Sync,
 {
-    let mut term = nexus_tui::TerminalHandle::new();
+    let mut term = nexus_tui::TerminalHandle::new(TERMINAL_MODE);
 
     let pp: PP<SP> = if gen {
         tracing::info!(

--- a/riscv/src/lib.rs
+++ b/riscv/src/lib.rs
@@ -50,7 +50,7 @@ pub fn parse_elf(bytes: &[u8]) -> Result<VM> {
 
 /// A structure describing a VM to load.
 /// This structure can be used with clap.
-#[derive(Debug, Args)]
+#[derive(Default, Debug, Args)]
 pub struct VMOpts {
     /// Instructions per step
     #[arg(short, name = "k", default_value = "1")]

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -29,7 +29,7 @@ clap.workspace = true
 nexus-tools-dev = { path = "./tools-dev", default-features = false }
 nexus-config = { path = "../config" }
 nexus-riscv = { path = "../riscv" }
-nexus-prover = { path = "../prover" }
+nexus-prover = { path = "../prover", features = ["verbose"] }
 nexus-tui = { path = "./tui" }
 
 ark-serialize.workspace = true

--- a/tools/src/command/prove.rs
+++ b/tools/src/command/prove.rs
@@ -132,7 +132,7 @@ fn save_proof<P: CanonicalSerialize>(proof: P, path: &Path) -> anyhow::Result<()
         "Saving the proof",
     );
 
-    let mut term = nexus_tui::TerminalHandle::new();
+    let mut term = nexus_tui::TerminalHandle::new_enabled();
     let mut context = term.context("Saving").on_step(|_step| "proof".into());
     let _guard = context.display_step();
 

--- a/tools/src/command/verify.rs
+++ b/tools/src/command/verify.rs
@@ -55,7 +55,7 @@ fn verify_proof(
     .context("path is not utf8")?
     .to_owned();
 
-    let mut term = nexus_tui::TerminalHandle::new();
+    let mut term = nexus_tui::TerminalHandle::new_enabled();
     let mut ctx = term.context("Verifying").on_step(move |_step| {
         match nova_impl {
             NovaImpl::Parallel => "root",

--- a/tools/tui/src/lib.rs
+++ b/tools/tui/src/lib.rs
@@ -4,4 +4,4 @@ mod component;
 mod thread;
 
 pub mod terminal;
-pub use terminal::TerminalHandle;
+pub use terminal::{TerminalHandle, Mode};

--- a/tools/tui/src/lib.rs
+++ b/tools/tui/src/lib.rs
@@ -4,4 +4,4 @@ mod component;
 mod thread;
 
 pub mod terminal;
-pub use terminal::{TerminalHandle, Mode};
+pub use terminal::{Mode, TerminalHandle};

--- a/tools/tui/src/terminal.rs
+++ b/tools/tui/src/terminal.rs
@@ -126,7 +126,7 @@ impl TerminalContext<'_> {
 
     pub fn display_step(&mut self) -> Guard<'_> {
         let Some(term) = &mut self.term.0 else {
-            return Guard { sender: None }
+            return Guard { sender: None };
         };
 
         self.steps_left = self

--- a/tools/tui/src/terminal.rs
+++ b/tools/tui/src/terminal.rs
@@ -2,32 +2,62 @@ use std::sync::mpsc;
 
 use super::{action::Action, component::FmtDuration, thread as tui_thread};
 
-pub struct TerminalHandle {
+/// Terminal output mode.
+#[derive(Debug, Copy, Clone)]
+pub enum Mode {
+    /// Default mode with enabled terminal rendering.
+    Enabled,
+    /// No output mode.
+    Disabled,
+}
+
+pub struct TerminalHandle(Option<TerminalHandleInner>);
+
+struct TerminalHandleInner {
     thread: tui_thread::ThreadHandle,
     ctx_sender: Option<mpsc::Sender<()>>,
 }
 
-impl Default for TerminalHandle {
+impl Default for TerminalHandleInner {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl TerminalHandle {
+impl TerminalHandleInner {
     pub fn new() -> Self {
         Self {
             thread: tui_thread::ThreadHandle::new(),
             ctx_sender: None,
         }
     }
+}
+
+impl TerminalHandle {
+    pub fn new(mode: Mode) -> Self {
+        match mode {
+            Mode::Enabled => Self::new_enabled(),
+            Mode::Disabled => Self(None),
+        }
+    }
+
+    pub fn new_enabled() -> Self {
+        if superconsole::SuperConsole::compatible() {
+            Self(TerminalHandleInner::new().into())
+        } else {
+            Self(None)
+        }
+    }
 
     pub fn context(&mut self, step_header: &'static str) -> TerminalContext<'_> {
-        let _ = self.ctx_sender.take();
-        TerminalContext {
-            term: self,
-            action: Some(Action { step_header, ..Default::default() }),
-            steps_left: 1,
-        }
+        let _ = self.0.as_mut().map(|handle| handle.ctx_sender.take());
+        let action = if self.0.is_some() {
+            Some(Action { step_header, ..Default::default() })
+        } else {
+            None
+        };
+
+        TerminalContext { term: self, action, steps_left: 1 }
     }
 }
 
@@ -95,16 +125,20 @@ impl TerminalContext<'_> {
     }
 
     pub fn display_step(&mut self) -> Guard<'_> {
+        let Some(term) = &mut self.term.0 else {
+            return Guard { sender: None }
+        };
+
         self.steps_left = self
             .steps_left
             .checked_sub(1)
             .expect("steps number overflow");
-        let ctx_sender = &mut self.term.ctx_sender;
+        let ctx_sender = &mut term.ctx_sender;
 
         let sender = if let Some(action) = self.action.take() {
             ctx_sender.get_or_insert_with(|| {
                 let (tx, rx) = mpsc::channel();
-                let _ = self.term.thread.sender().send((action, rx));
+                let _ = term.thread.sender().send((action, rx));
                 tx
             })
         } else {


### PR DESCRIPTION
cargo-like output is only enabled with optional `verbose` feature, so the `nexus-prover` crate can be used as a library crate (although `run` still does prints into console)