### PR TITLE
Fix broken links to quick start, white paper, and TinyRAM

### DIFF
--- a/docs/pages/Specs/nexus-vm.mdx
+++ b/docs/pages/Specs/nexus-vm.mdx
@@ -248,6 +248,6 @@ Though we first expect to implement these special functions as part of the Nexus
 
 [[STW23](https://eprint.iacr.org/2023/552)] Srinath Setty, Justin Thaler, and Riad Wahby. “Customizable constraint systems for succinct arguments”. In: Cryptology ePrint Archive (2023)
 
-[TinyRAM]: (https://www.scipr-lab.org/doc/TinyRAM-spec-2.000.pdf)
+[TinyRAM]: https://www.scipr-lab.org/doc/TinyRAM-spec-2.000.pdf
 [RISCZero]: (https://www.risczero.com)
 [zkMISP]: (https://whitepaper.zkm.io/whitepaper1.2.pdf)

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -91,7 +91,7 @@ And verification is as simple as running:
 cargo nexus verify
 ```
 
-To get started with the Nexus zkVM, check out the [Quick Start](/quick-start.mdx) guide.
+To get started with the Nexus zkVM, check out the [Quick Start](zkVM/quick-start.mdx) guide.
 
 <Callout type="info" emoji="ℹ️">
   Nexus is in experimental stages and not recommended for production use. The system has low performance and high costs. Many future upgrades are expected.
@@ -109,7 +109,7 @@ Open-source and fully-transparent science, cryptography and benchmarks are the c
 
 ## Architecture and Science
 
-For an in depth look at the science behind the Nexus zkVM and the Nexus Network, see the [Nexus Whitepaper](https://nexus.xyz/whitepaper). We briefly describe the Nexus system.
+For an in depth look at the science behind the Nexus zkVM and the Nexus Network, see the [Nexus Whitepaper](https://www.nexus.xyz/whitepaper.pdf). We briefly describe the Nexus system.
 
 ### The Nexus zkVM
 
@@ -147,4 +147,4 @@ The Nexus Virtual Machine (NVM) is a simple and minimal Instruction Set Architec
 
 Many more details will be released in the coming months.
 
-Next, try out the Nexus zkVM yourself to prove example Rust programs: See the [Quick Start](/quick-start.mdx) guide.
+Next, try out the Nexus zkVM yourself to prove example Rust programs: See the [Quick Start](zkVM/quick-start.mdx) guide.


### PR DESCRIPTION
Fixes these broken (404) links
- https://docs.nexus.xyz/quick-start
- https://nexus.xyz/whitepaper
- https://docs.nexus.xyz/Specs/(https:/www.scipr-lab.org/doc/TinyRAM-spec-2.000.pdf)

Tested with `npm run dev`