### PR TITLE
Fix Register Passing for Syscalls

### DIFF
--- a/riscv/src/eval.rs
+++ b/riscv/src/eval.rs
@@ -176,7 +176,7 @@ pub fn eval_inst(vm: &mut VM) -> Result<()> {
         }
         FENCE | EBREAK => {}
         ECALL => {
-            vm.syscalls.syscall(vm.regs.pc, vm.regs.x, &vm.mem)?;
+            vm.syscalls.syscall(vm.regs.pc, &mut vm.regs.x, &vm.mem)?;
         }
         UNIMP => {
             PC = vm.inst.pc;

--- a/vm/src/eval.rs
+++ b/vm/src/eval.rs
@@ -99,7 +99,7 @@ pub fn eval_step(vm: &mut NexusVM<impl Memory>) -> Result<()> {
         HALT => {
             PC = vm.pc;
         }
-        SYS => vm.syscalls.syscall(vm.pc, vm.regs, &vm.memory)?,
+        SYS => vm.syscalls.syscall(vm.pc, &mut vm.regs, &vm.memory)?,
 
         JAL => {
             vm.Z = add32(vm.pc, 8);

--- a/vm/src/syscalls.rs
+++ b/vm/src/syscalls.rs
@@ -37,7 +37,7 @@ impl Syscalls {
         self.input = slice.to_owned().into();
     }
 
-    pub fn syscall(&mut self, pc: u32, mut regs: [u32; 32], memory: &impl Memory) -> Result<()> {
+    pub fn syscall(&mut self, pc: u32, regs: &mut [u32; 32], memory: &impl Memory) -> Result<()> {
         let num = regs[18]; // s2 = x18  syscall number
         let a0 = regs[10]; // a0 = x10
         let a1 = regs[11]; // a1 = x11


### PR DESCRIPTION
Pass registers by mutable reference for syscalls to allow private input tape reading/writing.