### PR TITLE
Change NVM Syscall Specification

### DIFF
--- a/riscv/src/eval.rs
+++ b/riscv/src/eval.rs
@@ -176,7 +176,7 @@ pub fn eval_inst(vm: &mut VM) -> Result<()> {
         }
         FENCE | EBREAK => {}
         ECALL => {
-            vm.syscalls.syscall(vm.regs.pc, vm.regs.x, &vm.mem)?;
+            vm.Z = vm.syscalls.syscall(vm.regs.pc, vm.regs.x, &vm.mem)?;
         }
         UNIMP => {
             PC = vm.inst.pc;

--- a/riscv/src/nvm.rs
+++ b/riscv/src/nvm.rs
@@ -157,6 +157,14 @@ fn translate_inst(rv: RVInst) -> (u32, Inst) {
         }
         RV32::ECALL => {
             inst.opcode = SYS;
+            // Per the RISC-V spec, for an ecall `rd = 0` and the system determines
+            // how to return a value, e.g. by modifying register `x10` (aka `a0`).
+            //
+            // For the NVM, we formalize this by setting `rd = 10` and having each
+            // ecall modify `x10`, even if to just write zero. By doing so, we know
+            // that `rd` points to the modified register, and so we will always
+            // generate the R1CS circuit constraints correctly.
+            inst.rd = 10;
         }
         RV32::FENCE | RV32::EBREAK => {
             inst.opcode = NOP;

--- a/vm/src/eval.rs
+++ b/vm/src/eval.rs
@@ -99,8 +99,9 @@ pub fn eval_step(vm: &mut NexusVM<impl Memory>) -> Result<()> {
         HALT => {
             PC = vm.pc;
         }
-        SYS => vm.syscalls.syscall(vm.pc, vm.regs, &vm.memory)?,
-
+        SYS => {
+            vm.Z = vm.syscalls.syscall(vm.pc, vm.regs, &vm.memory)?;
+        }
         JAL => {
             vm.Z = add32(vm.pc, 8);
             let XI = add32(X, I);

--- a/vm/src/syscalls.rs
+++ b/vm/src/syscalls.rs
@@ -37,7 +37,7 @@ impl Syscalls {
         self.input = slice.to_owned().into();
     }
 
-    pub fn syscall(&mut self, pc: u32, mut regs: [u32; 32], memory: &impl Memory) -> Result<u32> {
+    pub fn syscall(&mut self, pc: u32, regs: [u32; 32], memory: &impl Memory) -> Result<u32> {
         let num = regs[18]; // s2 = x18  syscall number
         let inp1 = regs[10]; // a0 = x10
         let inp2 = regs[11]; // a1 = x11


### PR DESCRIPTION
In the RISC-V spec, the `rd` value for ECALL instructions is set to `0`, and the system defines how to read and modify the state in order to pass information to and from the external functionality.

This is slightly annoying from the perspective of circuit generation, since we currently use `rd` to figure out where the instruction returns in order to make sure that later instructions have the right view of the memory. So with this PR we define the NVM to deviate from the RISC-V spec, and to just set `rd = 10` (identifying `x10 = a0` as the return destination) for any syscall, and then for the VM to stick the syscall output there as appropriate. 

This allows us to read in information from the environment through a syscall without any modification needed to the circuit generation.