### PR TITLE
Fix CI: broke on `main` following Rust 1.78.0 release today

### DIFF
--- a/nova/src/gadgets/nonnative/mod.rs
+++ b/nova/src/gadgets/nonnative/mod.rs
@@ -35,6 +35,7 @@ where
     /// The mode of allocation is decided by `mode`.
     ///
     /// This should not create any constraints.
+    #[allow(dead_code)]
     fn new_variable_unconstrained<T: Borrow<V>>(
         cs: impl Into<Namespace<F>>,
         f: impl FnOnce() -> Result<T, SynthesisError>,

--- a/spartan/src/transcript.rs
+++ b/spartan/src/transcript.rs
@@ -8,6 +8,7 @@ pub trait ProofTranscript<G: CurveGroup> {
   fn append_scalar(&mut self, label: &'static [u8], scalar: &G::ScalarField);
   fn append_scalars(&mut self, label: &'static [u8], scalars: &[G::ScalarField]);
   fn append_point(&mut self, label: &'static [u8], point: &G);
+  #[allow(dead_code)]
   fn append_points(&mut self, label: &'static [u8], points: &[G]);
   fn challenge_scalar(&mut self, label: &'static [u8]) -> G::ScalarField;
   fn challenge_vector(&mut self, label: &'static [u8], len: usize) -> Vec<G::ScalarField>;

--- a/vm/src/circuit/r1cs.rs
+++ b/vm/src/circuit/r1cs.rs
@@ -348,7 +348,7 @@ impl R1CS {
                         let mut rv = format!("{i}");
                         for (n, j) in &self.vars {
                             if *j == i {
-                                rv = n.clone();
+                                rv.clone_from(n);
                             }
                         }
                         println!("{} * {} (name {})", v[i], self.w[i], rv);


### PR DESCRIPTION
_see [broken CI run on `main`](https://github.com/nexus-xyz/nexus-zkvm/actions/runs/8926309663)_

- Explicitly `#[allow(dead_code)]` on two currently unused trait functions.
- Use `Clone::clone_from` instead of `Clone::clone` (see lint: https://rust-lang.github.io/rust-clippy/master/index.html#/assigning_clones)