### PR TITLE
Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
     attributes:
       label: Program Information
       description: |
-        Provide information about your zkVM program, ideally a minimal example to replicate the bug.
+        Provide information about your zkVM program (i.e., your program that runs _inside_ the Nexus zkVM), ideally a minimal example to replicate the bug.
       placeholder: Program information
     validations:
       required: true
@@ -32,9 +32,9 @@ body:
     attributes:
       label: Project Information
       description: |
-        Provide information about your project using the Nexus zkVM, ideally a minimal example to replicate the bug.
+        Provide information about your project using the Nexus zkVM (i.e., your program that invokes the zkVM, if any), ideally a minimal example to replicate the bug.
     validations:
-      required: true
+      required: false
   - type: textarea
     id: steps-to-reproduce
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: "Bug Report"
+description: Report something that is broken or just not working as it should
+title: "[BUG]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **Before You Start...**
+
+        This form is only for submitting bug reports. If you have a usage question
+        or are unsure if this is really a bug, make sure to:
+
+        - Read the [docs](https://github.com/nexus-xyz/nexus-zkvm)
+        - Ask on [Telegram Chat](https://t.me/nexus_zkvm)
+        - Ask on [Github Discussions](https://github.com/nexus-xyz/nexus-zkvm/discussions)
+
+        Also try to search for your issue - it may have already been answered or even fixed in main or a development branch but not yet released.
+
+        However, if you find that an old, closed issue still persists in the latest version, you should open a new issue using the form below instead of commenting on the old issue.
+  - type: textarea
+    id: program-info
+    attributes:
+      label: Program information
+      description: |
+        Provide information about your Nexus program, ideally a minimal example to replicate the bug.
+      placeholder: Program information
+    validations:
+      required: true
+  - type: textarea
+    id: program-info
+    attributes:
+      label: Project information
+      description: |
+        Provide information about your project using the Nexus zkVM, ideally a minimal example to replicate the bug.
+      placeholder: Project information
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: |
+        What exactly is your application doing that causes the zkVM to malfunction?
+
+        If we have to investigate the issue, what would we have to do to reproduce the issue?
+      placeholder: Steps to reproduce.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What is expected?
+      description: |
+        This can range from a textual explanation of what you were expecting to see/happen to providing the output of your program when run outside of/or in a different mode of the zkVM.
+    validations:
+      required: true
+  - type: textarea
+    id: actually-happening
+    attributes:
+      label: What is actually happening?
+      description: |
+        Explain what is happening that deviates from the expected output.
+    validations:
+      required: true
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System Info
+      description: |
+        Provide as much information about the environment you are using.
+      render: shell
+      placeholder: Operating system, architecture, etc...
+  - type: textarea
+    id: additional-comments
+    attributes:
+      label: Any additional comments?
+      description: e.g. some background/context of how you ran into this bug.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
     attributes:
       label: Program information
       description: |
-        Provide information about your Nexus program, ideally a minimal example to replicate the bug.
+        Provide information about your zkVM program, ideally a minimal example to replicate the bug.
       placeholder: Program information
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
   - type: textarea
     id: program-info
     attributes:
-      label: Program information
+      label: Program Information
       description: |
         Provide information about your zkVM program, ideally a minimal example to replicate the bug.
       placeholder: Program information
@@ -30,21 +30,19 @@ body:
   - type: textarea
     id: program-info
     attributes:
-      label: Project information
+      label: Project Information
       description: |
         Provide information about your project using the Nexus zkVM, ideally a minimal example to replicate the bug.
-      placeholder: Project information
     validations:
       required: true
   - type: textarea
     id: steps-to-reproduce
     attributes:
-      label: Steps to reproduce
+      label: Reproduction Steps
       description: |
         What exactly is your application doing that causes the zkVM to malfunction?
 
         If we have to investigate the issue, what would we have to do to reproduce the issue?
-      placeholder: Steps to reproduce.
     validations:
       required: true
   - type: textarea
@@ -66,11 +64,9 @@ body:
   - type: textarea
     id: system-info
     attributes:
-      label: System Info
+      label: System Information
       description: |
         Provide as much information about the environment you are using.
-      render: shell
-      placeholder: Operating system, architecture, etc...
   - type: textarea
     id: additional-comments
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Telegram Chat
+    url: https://t.me/nexus_zkvm
+    about: Ask questions and discuss with other developers in real-time.
+  - name: Discussions
+    url: https://github.com/nexus-xyz/nexus-zkvm/discussions
+    about: Use GitHub discussions for message-board style questions and discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest new features for the zkVM
+title: '[FEATURE]: '
+labels: ['feature request']
+---
+
+### What problem does it solve
+What is the problem?
+
+### What is the solution
+What do you want to happen?
+
+### Existing alternatives
+What, if any, alternative solutions or features have you considered?
+
+### Additional notes
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,14 +5,14 @@ title: '[FEATURE]: '
 labels: ['feature request']
 ---
 
-### What problem does it solve
-What is the problem?
+### What is the problem?
+Answer here...
 
-### What is the solution
-What do you want to happen?
+### What do you want to happen?
+Answer here...
 
 ### Existing alternatives
 What, if any, alternative solutions or features have you considered?
 
 ### Additional notes
-Add any other context or screenshots about the feature request here.
+Add any other context or screenshots about the feature request can go here.


### PR DESCRIPTION
Candidate issue templates, derived from https://github.com/helldivers-2/api/tree/master/.github/ISSUE_TEMPLATE (was recommended to me as a particularly high quality template, and I agree).

Is configured to allow the user to select a blank issue template as well, but hopefully provides some additional structure to promote quality submissions.