### PR TITLE
Fix Broken Build

### DIFF
--- a/nova/src/circuits/nova/pcd/compression/secondary/conversion.rs
+++ b/nova/src/circuits/nova/pcd/compression/secondary/conversion.rs
@@ -24,8 +24,8 @@ pub enum GroupConversionError {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum ConversionError {
-    #[allow(dead_code)]
     Field(FieldConversionError),
     Group(GroupConversionError),
 }

--- a/nova/src/circuits/nova/pcd/compression/secondary/conversion.rs
+++ b/nova/src/circuits/nova/pcd/compression/secondary/conversion.rs
@@ -25,6 +25,7 @@ pub enum GroupConversionError {
 
 #[derive(Debug)]
 pub enum ConversionError {
+    #[allow(dead_code)]
     Field(FieldConversionError),
     Group(GroupConversionError),
 }


### PR DESCRIPTION
As described, triggered by the [Rust 1.79.0 release](https://github.com/rust-lang/rust/releases/tag/1.79.0).