### PR TITLE
Describe how to run private input example

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -4,4 +4,9 @@ This is a **low-level, unstable** API for programmatically accessing the Nexus V
 
 The roadmap is for it to be supplanted by a more strategically designed and consistent Nexus SDK. The API will likely shift as part of the SDK development effort.
 
-The API is relatively self-documenting, see `./src/lib.rs`. Examples of using the API are given in `./examples`.
+The API is relatively self-documenting, see `./src/lib.rs`. Examples of using the API are given in `./examples`. The examples can be run with, for instance:
+
+```sh
+nexus-zkvm/examples$ cargo build -r
+nexus-zkvm/api$ cargo run -r --example prover_run
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,3 +14,9 @@ configured as the default for cargo in this crate:
 ```sh
 cargo run -r --bin example
 ```
+
+## Testing examples with private inputs
+
+Some examples expect private inputs. An example of
+programmatically invoking a program with a private input can be
+found in `/api/examples/prover_run.rs`.


### PR DESCRIPTION
I was running examples in `/nexus-zkvm/examples`. I realized `private_input` example is not doing the most interesting thing it can do:

```
 % cargo run -r --bin private_input
    Finished release [optimized] target(s) in 0.28s
     Running `nexus-run /Users/yh/shared/nexus/nexus-zkvm/target/riscv32i-unknown-none-elf/release/private_input`
No private input provided...
```

This PR adds some hints in README files that help people run examples with private inputs.