### PR TITLE
Comment on no more private input case

### DIFF
--- a/vm/src/syscalls.rs
+++ b/vm/src/syscalls.rs
@@ -56,7 +56,7 @@ impl Syscalls {
             // read_from_private_input
             match self.input.pop_front() {
                 Some(b) => out = b as u32,
-                None => out = u32::MAX,
+                None => out = u32::MAX, // out of range of possible u8 inputs
             }
         } else {
             return Err(UnknownECall(pc, num));


### PR DESCRIPTION
The private input reading syscall returns `u32::MAX` in case no more inputs are available. Are we confusing two cases (1) the next private input is `u32::MAX` and (2) there are no next private input.

The answer is no and this commit documents why.