### PR TITLE
Fix comment about trace() function

### DIFF
--- a/vm/src/trace.rs
+++ b/vm/src/trace.rs
@@ -145,8 +145,8 @@ fn k_step<M: Memory>(vm: &mut NexusVM<M>, k: usize) -> Result<Block<M::Proof>> {
 }
 
 /// Generate a program trace by evaluating `vm`, using `k` steps
-/// per block. If `pow` is true, the total number of steps will
-/// be rounded up to the nearest power of two by inserting UNIMP
+/// per block. If `pow` is true, the number of blocks will be
+/// rounded up to the nearest power of two by inserting UNIMP
 /// instructions.
 pub fn trace<M: Memory>(vm: &mut NexusVM<M>, k: usize, pow: bool) -> Result<Trace<M::Proof>> {
     let mut trace = Trace { k, start: 0, blocks: Vec::new() };


### PR DESCRIPTION
The comment stated that `pow == true` is about the number of **steps**, but the implementation was making the number of **blocks** to be a power of two. These are different especially when `k` is not a power-of-two.

This commit fixes the comment according to the implementation. Otherwise, if we followed the original comment, the operation might not terminate (for example when `k` is three).