### PR TITLE
chore: check examples in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           toolchain: stable
       - run: cargo build --all-features
+      - run: cargo build --all-features --examples
       - run: cd nova-benches && cargo bench --no-run
 
   cargo-clippy:
@@ -37,6 +38,7 @@ jobs:
       - run: cargo clippy --all-targets --all-features
 
   test:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
https://github.com/nexus-xyz/nexus-zkvm/pull/197 adds an example that actually fails to build when run with
```sh
cargo build --examples # works with --all-features
```

Examples used to be ignored, we should check them in ci.
I kept `all-features` because hypernova example is removed in https://github.com/nexus-xyz/nexus-zkvm/pull/208