### PR TITLE
nexus-vm: allow limiting executed trace len

### DIFF
--- a/vm/src/error.rs
+++ b/vm/src/error.rs
@@ -43,6 +43,7 @@ pub enum NexusVMError {
     #[error("error hashing {0}")]
     HashError(String),
 
+    /// Reached the limit of executed instructions.
     #[error("reached maximum number of executed instructions: {0}")]
     MaxTraceLengthExceeded(usize),
 }

--- a/vm/src/error.rs
+++ b/vm/src/error.rs
@@ -42,6 +42,9 @@ pub enum NexusVMError {
     /// An error occured while hashing
     #[error("error hashing {0}")]
     HashError(String),
+
+    #[error("reached maximum number of executed instructions: {0}")]
+    MaxTraceLengthExceeded(usize),
 }
 
 /// Result type for VM functions that can produce errors

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -122,11 +122,9 @@ pub fn eval(vm: &mut NexusVM<impl Memory>, show: bool) -> Result<()> {
         );
     }
     let t = std::time::Instant::now();
-    let mut count = 0;
 
     loop {
         eval_inst(vm)?;
-        count += 1;
         if show {
             println!("{:50} {:8x} {:8x}", vm.inst, vm.Z, vm.regs.pc);
         }
@@ -149,7 +147,11 @@ pub fn eval(vm: &mut NexusVM<impl Memory>, show: bool) -> Result<()> {
         println!("\nFinal Machine State: pc: {:x}", vm.regs.pc);
         table("x", &vm.regs.x);
 
-        println!("Executed {count} instructions in {:?}", t.elapsed());
+        println!(
+            "Executed {} instructions in {:?}",
+            vm.trace_len,
+            t.elapsed()
+        );
     }
     Ok(())
 }

--- a/vm/src/trace.rs
+++ b/vm/src/trace.rs
@@ -338,7 +338,6 @@ mod test {
             }
         }
         assert_eq!(nvm.regs.pc, pc);
-        println!("{}", nvm.trace_len);
     }
 
     #[test]

--- a/vm/src/trace.rs
+++ b/vm/src/trace.rs
@@ -320,7 +320,13 @@ fn parse_alt<P: MemoryProof>(regs: &Regs, word: u32) -> Witness<P> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::{machines::loop_vm, memory::paged::Paged, memory::trie::MerkleTrie};
+    use crate::{
+        eval,
+        machines::{loop_vm, nop_vm},
+        memory::paged::Paged,
+        memory::trie::MerkleTrie,
+        NexusVMError,
+    };
 
     // basic check that tracing and iteration succeeds
     fn trace_test_machine(mut nvm: NexusVM<impl Memory>) {
@@ -332,11 +338,36 @@ mod test {
             }
         }
         assert_eq!(nvm.regs.pc, pc);
+        println!("{}", nvm.trace_len);
     }
 
     #[test]
     fn trace_test_machines() {
         trace_test_machine(loop_vm::<Paged>(5));
         trace_test_machine(loop_vm::<MerkleTrie>(5));
+    }
+
+    #[test]
+    fn run_with_trace_limit() {
+        let mut vm = nop_vm::<MerkleTrie>(10);
+        // should fail because of appended UNIMP
+        vm.set_max_trace_len(10);
+
+        let result = eval(&mut vm, false);
+        assert!(matches!(
+            result,
+            Err(NexusVMError::MaxTraceLengthExceeded(len)) if len == 10
+        ));
+
+        // try with trace
+        let k = 1;
+        let mut vm = nop_vm::<MerkleTrie>(10);
+        vm.set_max_trace_len(10);
+
+        let result = trace(&mut vm, k, false);
+        assert!(matches!(
+            result,
+            Err(NexusVMError::MaxTraceLengthExceeded(len)) if len == 10
+        ));
     }
 }


### PR DESCRIPTION
Small change to allow limiting the number of executed instruction on the VM instance.

Combined with the limit of the ELF file size, this can serve as a spam protection for the cloud.
With the current setup executing a program barely takes any time compared to proving it. So gas metering would be an overkill since the type of instruction shouldn't affect prover time.