### PR TITLE
Add and fix smoke tests on prove and verify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,12 @@ jobs:
         with:
           toolchain: stable
       - run: cargo test -r --all-features
+
+  test-smoke:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup target add riscv32i-unknown-none-elf
+      - run: assets/scripts/smoke.sh examples/src/bin/fib3.rs
+      - run: assets/scripts/smoke.sh examples/src/bin/hello.rs

--- a/assets/scripts/smoke.sh
+++ b/assets/scripts/smoke.sh
@@ -25,7 +25,7 @@ if [ ! -f "$1" ]; then
 fi
 
 if [ -e $PROJECT_NAME ]; then
-    echo "Error: Directory 'nexus-project-ci' already exists."
+    echo "Error: Directory '$PROJECT_NAME' already exists."
     exit 1
 fi
 

--- a/assets/scripts/smoke.sh
+++ b/assets/scripts/smoke.sh
@@ -1,0 +1,54 @@
+#! /bin/bash
+
+# This script follows steps written in README.md
+# Using the rust file specified as the unique argument.
+
+# Call at the top directory of the nexus-zkvm project
+# For example:
+# ./assets/scripts/e2e.sh examples/src/bin/fib3.rs
+
+# Every command needs to succeed
+set -e
+
+ORIGINAL_DIR=`pwd`
+PROJECT_NAME="nexus-project-ci"
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <file.rs>"
+    exit 1
+fi
+
+if [ ! -f "$1" ]; then
+    echo "Usage: $0 <file.rs>"
+    echo "where <file.rs> is a path to a file."
+    exit 1
+fi
+
+if [ -e $PROJECT_NAME ]; then
+    echo "Error: Directory 'nexus-project-ci' already exists."
+    exit 1
+fi
+
+set -x
+
+cp -n Cargo.toml Cargo.toml.bkp
+
+error_handler() {
+    echo "Error occured in e2e.sh: : ${1}. Exiting."
+    cd $ORIGINAL_DIR
+    rm -rf $PROJECT_NAME
+    mv -f Cargo.toml.bkp Cargo.toml
+    exit 1
+}
+trap 'error_handler ${LINENO}' ERR
+
+cargo build --release --package nexus-tools --bin cargo-nexus
+./target/release/cargo-nexus nexus new $PROJECT_NAME
+cp $1 $PROJECT_NAME/src/main.rs
+cd $PROJECT_NAME
+../target/release/cargo-nexus nexus run
+../target/release/cargo-nexus nexus prove
+../target/release/cargo-nexus nexus verify
+cd $ORIGINAL_DIR
+rm -rf $PROJECT_NAME
+mv -f Cargo.toml.bkp Cargo.toml

--- a/assets/scripts/smoke.sh
+++ b/assets/scripts/smoke.sh
@@ -36,7 +36,9 @@ cp -n Cargo.toml Cargo.toml.bkp
 cleanup() {
     cd $ORIGINAL_DIR
     rm -rf $PROJECT_NAME
-    mv -f Cargo.toml.bkp Cargo.toml
+    if [ -f Cargo.toml.bkp ]; then
+        mv -f Cargo.toml.bkp Cargo.toml
+    fi
 }
 trap cleanup SIGINT
 

--- a/assets/scripts/smoke.sh
+++ b/assets/scripts/smoke.sh
@@ -33,11 +33,16 @@ set -x
 
 cp -n Cargo.toml Cargo.toml.bkp
 
-error_handler() {
-    echo "Error occured in e2e.sh: : ${1}. Exiting."
+cleanup() {
     cd $ORIGINAL_DIR
     rm -rf $PROJECT_NAME
     mv -f Cargo.toml.bkp Cargo.toml
+}
+trap cleanup SIGINT
+
+error_handler() {
+    echo "Error occured in smoke.sh: : ${1}. Exiting."
+    cleanup
     exit 1
 }
 trap 'error_handler ${LINENO}' ERR
@@ -49,6 +54,4 @@ cd $PROJECT_NAME
 ../target/release/cargo-nexus nexus run
 ../target/release/cargo-nexus nexus prove
 ../target/release/cargo-nexus nexus verify
-cd $ORIGINAL_DIR
-rm -rf $PROJECT_NAME
-mv -f Cargo.toml.bkp Cargo.toml
+cleanup

--- a/assets/scripts/smoke.sh
+++ b/assets/scripts/smoke.sh
@@ -5,7 +5,7 @@
 
 # Call at the top directory of the nexus-zkvm project
 # For example:
-# ./assets/scripts/e2e.sh examples/src/bin/fib3.rs
+# ./assets/scripts/smoke.sh examples/src/bin/fib3.rs
 
 # Every command needs to succeed
 set -e

--- a/examples/src/bin/fib3.rs
+++ b/examples/src/bin/fib3.rs
@@ -1,0 +1,18 @@
+// Used in the CI as a small example that uses memory store
+#![no_std]
+#![no_main]
+
+fn fib(n: u32) -> u32 {
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => fib(n - 1) + fib(n - 2),
+    }
+}
+
+#[nexus_rt::main]
+fn main() {
+    let n = 3;
+    let result = fib(n);
+    assert_eq!(result, 2);
+}

--- a/examples/src/bin/hello.rs
+++ b/examples/src/bin/hello.rs
@@ -1,0 +1,11 @@
+#![no_std]
+#![no_main]
+
+extern crate alloc;
+
+use nexus_rt::println;
+
+#[nexus_rt::main]
+fn main() {
+    println!("Hello!");
+}

--- a/vm/src/trace.rs
+++ b/vm/src/trace.rs
@@ -236,7 +236,7 @@ impl<P: MemoryProof> Iterator for BlockIter<'_, P> {
 
         let s = &self.block.steps[self.index];
         let inst = parse_u32(s.inst).unwrap();
-        let mut w = parse_alt(&self.block.regs, s.inst);
+        let mut w = parse_alt(&self.regs, s.inst);
         w.regs = self.regs.clone();
         w.inst = s.inst;
         w.J = inst.index_j();


### PR DESCRIPTION
This MR aims at preventing regression of https://github.com/nexus-xyz/nexus-zkvm/pull/213 , where a newly added constraint broke the examples mentioned in README.md.

This MR
- adds a shell script `smoke.sh` that runs `cargo-nexus nexus {run,prove,verify}`
- adds two lightweight examples in `examples/src/bin` that detect the issue fixed in https://github.com/nexus-xyz/nexus-zkvm/pull/213
- adds the new examples in the CI
- fixes the proving implementation so that the new smoke tests pass
