### PR TITLE
Add circuit checking one of "J=?" variables contains one

### DIFF
--- a/vm/src/circuit/r1cs.rs
+++ b/vm/src/circuit/r1cs.rs
@@ -610,6 +610,18 @@ mod test {
         }
     }
 
+    #[test]
+    fn test_set_bit() {
+        let mut cs = R1CS::default();
+        cs.set_bit("b0", false);
+        cs.set_bit("b1", true);
+        cs.eqi("b0", ZERO);
+        cs.eqi("b1", ONE);
+        cs.addi("b1", "b0", ONE);
+        cs.mul("b0", "b1", "b0");
+        assert!(cs.is_sat());
+    }
+
     fn test_mem(set: &[u32]) {
         for &x in set {
             let mut cs = R1CS::default();

--- a/vm/src/circuit/riscv.rs
+++ b/vm/src/circuit/riscv.rs
@@ -417,7 +417,7 @@ fn parse_shamt(cs: &mut R1CS, Y: u32) {
 fn parse_J(cs: &mut R1CS, J: u32) {
     cs.set_var("J", J);
     for j in 1..=RV32::MAX_J {
-        cs.set_var(&format!("J={j}"), (j == J).into());
+        cs.set_bit(&format!("J={j}"), j == J);
     }
 
     // used by ALU instructions

--- a/vm/src/circuit/riscv.rs
+++ b/vm/src/circuit/riscv.rs
@@ -521,6 +521,15 @@ fn parse_J(cs: &mut R1CS, J: u32) {
     cs.mul("J=41", "opcode=115", "inst_20"); // ebreak
     cs.mul("J=42", "opcode=115", "inst_12"); // unimp
 
+    // One of J=? variables hold
+    cs.constraint(|cs, a, b, c| {
+        for j in 1..=RV32::MAX_J {
+            a[cs.var(&format!("J={j}"))] = ONE;
+        }
+        b[0] = ONE;
+        c[0] = ONE;
+    });
+
     cs.seal();
 }
 


### PR DESCRIPTION
I could not find a circuit constraint checking that one of "J=?" variables hold. So I added some checks around "J=?" variables.

* I started using `set_bit()` instead of `set_var()` for creating these variables. This forces their values to be zero or one.
* I added a check that the sum of "J=?" variables equals to one. This makes sure only one of these variables contains one (overflow is impossible).