### PR TITLE
Fix Memory Limit Example

### DIFF
--- a/examples/src/bin/memlimit.rs
+++ b/examples/src/bin/memlimit.rs
@@ -7,10 +7,10 @@ use core::hint::black_box;
 use nexus_rt::println;
 
 // use 16mb
-// alternatively, remove memlimit argument or otherwise set less than (slightly more than) 6mb and it will fail
-#[nexus_rt::main(memlimit = 16)]
+// alternatively, remove memlimit argument or otherwise set less than (slightly more than) 16mb and it will fail
+#[nexus_rt::main(memlimit = 18)]
 fn main() {
-    let vec = vec![0 as u32; 1500000];
+    let vec = vec![1 as u8; 0x1000000];
     black_box(vec);
 
     println!("Success!!!");

--- a/runtime/asm.S
+++ b/runtime/asm.S
@@ -18,7 +18,7 @@ _start:
     la gp, __global_pointer$
     .option pop
 
-    la sp, __memory_top - 4
+    la sp, __memory_top - 4 /* start growing the stack (down) from here */
     mv fp, sp
 
     jal ra, _get_stack_size
@@ -44,7 +44,7 @@ abort:
 alloc_:
     lw s0, _heap
     add a0, a0, s0
-    bgeu a0, sp, abort
+    bgeu a0, sp, abort /* if requesting memory used by the stack, abort */ 
     la s1, _heap
     sw a0, 0(s1)
     mv a0, s0

--- a/runtime/linker-scripts/default.x
+++ b/runtime/linker-scripts/default.x
@@ -2,6 +2,11 @@ ENTRY(_start);
 
 SECTIONS
 {
+  /* Set the default size of the stack.                                                 */
+  /*                                                                                    */
+  /* Because the stack will grow down from this point, and if the heap requests memory  */
+  /* being used by the stack then the runtime will panic, this value also functions as  */
+  /* the memory limit for the guest program execution more generally.                   */
   __memory_top = 0x400000;
   . = 0;
 

--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -43,6 +43,10 @@ unsafe impl GlobalAlloc for Heap {
 }
 
 /// Stack size setup (_get_stack_size)
+///
+/// Because the stack will grow down from this point, and if the heap requests memory
+/// being used by the stack then the runtime will panic, this value also functions as
+/// the memory limit for the guest program execution more generally.
 #[doc(hidden)]
 #[link_section = ".init.rust"]
 #[export_name = "_get_stack_size"]


### PR DESCRIPTION
The memory limit example seems to have gotten jumbled at some point. This makes what's occurring a bit more clear. Setting the memory limit down to `16` (or smaller) will cause the execution to fail over.