### PR TITLE
speedup CI & check runtime build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
+          target: riscv32i-unknown-none-elf
       - run: cargo check --all-features
       - run: cargo check --all-features --examples
       - run: cargo check -p example --target=riscv32i-unknown-none-elf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,17 @@ jobs:
       - run: cargo fmt --all --check
       - run: cd nova-benches && cargo fmt --check
 
-  build:
+  check-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
-      - run: cargo build --all-features
-      - run: cargo build --all-features --examples
-      - run: cd nova-benches && cargo bench --no-run
+      - run: cargo check --all-features
+      - run: cargo check --all-features --examples
+      - run: cargo check -p example --target=riscv32i-unknown-none-elf
+      - run: cd nova-benches && cargo check --benches
 
   cargo-clippy:
     runs-on: ubuntu-latest
@@ -38,7 +39,7 @@ jobs:
       - run: cargo clippy --all-targets --all-features
 
   test:
-    needs: build
+    needs: check-build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -48,7 +49,7 @@ jobs:
       - run: cargo test -r --all-features
 
   test-smoke:
-    needs: build
+    needs: check-build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ default-members = [
     "tools",
     "network",
     "nova",
+    "runtime",
     "spartan",
     "core",
     "sdk",

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -11,3 +11,8 @@ categories = { workspace = true }
 
 [dependencies]
 nexus-rt = { path = "../runtime" }
+
+[lints.clippy]
+print_with_newline = { level = "allow", priority = 0 }
+needless_range_loop = { level = "allow", priority = 0 }
+manual_memcpy = { level = "allow", priority = 0 }

--- a/examples/src/bin/galeshapley.rs
+++ b/examples/src/bin/galeshapley.rs
@@ -22,9 +22,9 @@ fn stable_matching(
         let prefs = &employer_prefs[next];
 
         for c in prefs {
-            if candidates.contains(&c) {
+            if candidates.contains(c) {
                 hires[next] = Some(*c);
-                assert!(candidates.remove(&c));
+                assert!(candidates.remove(c));
 
                 break;
             } else {

--- a/examples/src/bin/keccak.rs
+++ b/examples/src/bin/keccak.rs
@@ -67,7 +67,7 @@ fn sha3_keccakf(st: &mut [u64; 25]) {
         for i in 0..24 {
             let j: u32 = keccakf_piln[i];
             bc[0] = st[j as usize];
-            st[j as usize] = rotl64(t, keccakf_rotc[i as usize]);
+            st[j as usize] = rotl64(t, keccakf_rotc[i]);
             t = bc[0];
         }
 
@@ -114,7 +114,7 @@ fn sha3_update(c: &mut Sha3, data: &[u8]) {
     let mut j = c.pt;
     for i in 0..len {
         unsafe {
-            c.data.b[j as usize] ^= data[i as usize];
+            c.data.b[j as usize] ^= data[i];
         }
         j += 1;
         if j >= c.rsiz {

--- a/examples/src/bin/memlimit.rs
+++ b/examples/src/bin/memlimit.rs
@@ -10,7 +10,7 @@ use nexus_rt::println;
 // alternatively, remove memlimit argument or otherwise set less than (slightly more than) 16mb and it will fail
 #[nexus_rt::main(memlimit = 18)]
 fn main() {
-    let vec = vec![1 as u8; 0x1000000];
+    let vec = vec![1u8; 0x1000000];
     black_box(vec);
 
     println!("Success!!!");

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,3 +13,6 @@ categories = { workspace = true }
 nexus-rt-macros = { path = "macros", version = "0.1.0" }
 postcard = { version = "1.0.8", features = ["alloc"] }
 serde = { version = "1.0", default-features = false }
+
+[lib]
+doctest = false

--- a/runtime/examples/basic.rs
+++ b/runtime/examples/basic.rs
@@ -3,9 +3,9 @@
 // optional, for use of collections, etc.
 extern crate alloc;
 
-use nexus_rt::print;
+use nexus_rt::println;
 
 #[nexus_rt::main]
 fn main() {
-    print!("Hello World\n");
+    println!("Hello World");
 }

--- a/runtime/src/ecalls.rs
+++ b/runtime/src/ecalls.rs
@@ -27,9 +27,6 @@ mod riscv32 {
     ///
     /// exhausts the private input tape, so can only be used once
     pub fn read_private_input<T: DeserializeOwned>() -> Result<T, postcard::Error> {
-        let inp: u32 = 0;
-        let mut out: u32 = 0;
-
         let bytes: alloc::vec::Vec<u8> = core::iter::from_fn(read_from_private_input).collect();
         postcard::from_bytes::<T>(bytes.as_slice())
     }
@@ -108,7 +105,7 @@ pub use std::{print, println};
 
 /// Read an object off the private input tape
 #[cfg(not(target_arch = "riscv32"))]
-pub fn read_private_input<T: DeserializeOwned>() -> Result<T, postcard::Error> {
+pub fn read_private_input<T: serde::de::DeserializeOwned>() -> Result<T, postcard::Error> {
     panic!("private input is not available outside of NexusVM")
 }
 
@@ -120,12 +117,12 @@ pub fn read_from_private_input() -> Option<u8> {
 
 /// Write an object to the output tape
 #[cfg(not(target_arch = "riscv32"))]
-pub fn write_output<T: Serialize + ?Sized>(val: &T) {
+pub fn write_output<T: serde::Serialize + ?Sized>(_: &T) {
     panic!("output is not available outside of NexusVM")
 }
 
 /// Write a slice to the output taoe
 #[cfg(not(target_arch = "riscv32"))]
-pub fn write_to_output(b: &[u8]) {
+pub fn write_to_output(_: &[u8]) {
     panic!("output is not available outside of NexusVM")
 }


### PR DESCRIPTION
`build` job was used as a prerequisite for tests, now unnecessarily slows down CI because tests need release build

& check examples on riscv target