### PR TITLE
Fix a dangling link

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -83,7 +83,7 @@ And verification is as simple as running:
 cargo nexus verify
 ```
 
-To get started with the Nexus zkVM, check out the [Quick Start](zkvm/quick-start.mdx) guide.
+To get started with the Nexus zkVM, check out the [SDK Quick Start](zkvm/sdk-quick-start.mdx) guide or the [CLI Quick Start](zkvm/cli-quick-start.mdx) guide.
 
 <Callout type="info" emoji="ℹ️">
   Nexus is in an experimental stage and is not currently recommended for production use. The system has low performance and high costs. Many future upgrades are expected.


### PR DESCRIPTION
The quick start guide has been renamed into two guides now. So we need to change the link to it as well.