### PR TITLE
Add a note where to run `cargo nexus host`

### DIFF
--- a/docs/pages/zkvm/cli-quick-start.mdx
+++ b/docs/pages/zkvm/cli-quick-start.mdx
@@ -41,6 +41,7 @@ This should print the available CLI commands.
 
 ### 2. Create a new Nexus project
 
+Somewhere out of the nexus-zkvm checkout, run:
 ```shell
 cargo nexus new nexus-project
 ```

--- a/docs/pages/zkvm/sdk-quick-start.mdx
+++ b/docs/pages/zkvm/sdk-quick-start.mdx
@@ -43,6 +43,7 @@ This should print the available CLI commands.
 
 To use the zkVM programmatically, we need two programs: a _guest_ program that runs on the zkVM, and a _host_ program that operates the zkVM itself.
 
+Somewhere out of the nexus-zkvm checkout, run:
 ```shell
 cargo nexus host nexus-host
 ```


### PR DESCRIPTION
Once I [could not follow](https://github.com/nexus-xyz/nexus-zkvm/pull/208#pullrequestreview-2178379349) the sdk quick guide. The reason was that I was running `cargo nexus host` command in the checkout directory of `nexus-zkvm`.

This PR adds a phrase in the quick start guide against running the command there.