### PR TITLE
Set smoke.sh to current runtime

### DIFF
--- a/assets/scripts/smoke.sh
+++ b/assets/scripts/smoke.sh
@@ -53,6 +53,8 @@ cargo build --release --package cargo-nexus --bin cargo-nexus
 ./target/release/cargo-nexus nexus new $PROJECT_NAME
 cp $1 $PROJECT_NAME/src/main.rs
 cd $PROJECT_NAME
+# Link the test program to the latest runtime code
+sed 's#git = "https://github.com/nexus-xyz/nexus-zkvm.git"#path = "../runtime"#' Cargo.toml > Cargo.tmp && mv Cargo.tmp Cargo.toml
 ../target/release/cargo-nexus nexus run
 ../target/release/cargo-nexus nexus prove
 ../target/release/cargo-nexus nexus verify


### PR DESCRIPTION
Set smoke.sh to current runtime

Summary:

Test Plan:

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/nexus-xyz/nexus-zkvm/pull/246).
* #250
* #249
* #248
* #247
* __->__ #246