### PR TITLE
Add MacOS tool in assemble.sh

### DIFF
--- a/runtime/assemble.sh
+++ b/runtime/assemble.sh
@@ -1,13 +1,19 @@
 #!/bin/sh
-
 set -e
 
-rm -f bin/*.a
+# Detect the operating system
+if [ "$(uname)" = "Darwin" ]; then
+    # macOS
+    GCC_PREFIX="riscv64-elf-"
+else
+    # Assume Linux
+    GCC_PREFIX="riscv-none-elf-"
+fi
 
+rm -f bin/***.a
 for ext in i imc
 do
-    riscv-none-elf-gcc -c -mabi=ilp32 -march=rv32${ext} -mcmodel=medlow asm.S -o bin/nexus-rt.o
-    riscv-none-elf-ar crs bin/riscv32${ext}-unknown-none-elf.a bin/nexus-rt.o
+    ${GCC_PREFIX}gcc -c -mabi=ilp32 -march=rv32${ext} -mcmodel=medlow asm.S -o bin/nexus-rt.o
+    ${GCC_PREFIX}ar crs bin/riscv32${ext}-unknown-none-elf.a bin/nexus-rt.o
 done
-
 rm bin/nexus-rt.o


### PR DESCRIPTION
Add MacOS tool in assemble.sh

Most of us use Mac.
I suggest change the command to native mactool.

Update:

This script will now detect if MacOS or not and use the tool accordingly.

Summary:

Test Plan:
