### PR TITLE
Clean up smoke.sh

### DIFF
--- a/assets/scripts/smoke.sh
+++ b/assets/scripts/smoke.sh
@@ -28,14 +28,9 @@ fi
 
 set -x
 
-cp -n Cargo.toml Cargo.toml.bkp
-
 cleanup() {
     cd "$ORIGINAL_DIR"
     rm -rf "$PROJECT_NAME"
-    if [ -f Cargo.toml.bkp ]; then
-        mv -f Cargo.toml.bkp Cargo.toml
-    fi
 }
 
 trap cleanup SIGINT


### PR DESCRIPTION
Clean up smoke.sh

Since we move smoke.sh output dir to /tmp.

The backup file of Cargo.toml is unneccessary anymore.
