### PR TITLE
Add Flamegraph via environment variable FLAMEGRAPH

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -32,6 +32,11 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
     "chrono",
     "env-filter",
 ] }
+# Flamegraph output filename
+chrono = { version = "0.4", default-features = false, features = [
+    "clock",
+    "std",
+] }
 
 cargo_metadata = "0.18.1"
 clap.workspace = true


### PR DESCRIPTION
Add Flamegraph via environment variable FLAMEGRAPH

Summary:

To generate flamegraph, user must:

- Install `samply`: `cargo install samply`

Then for operation users want to generate flamegraph, add environment variable, for example:

```
$ FLAMEGRAPH=1 cargo nexus run
$ FLAMEGRAPH=1 cargo nexus prove
$ FLAMEGRAPH=1 cargo nexus verify
```

And to open the flamegraph, run:

```
samply load profile_{date}_{time}.json
```
Where `date` and `time` are the time when the operation started.

Test Plan:

In `smoke.sh`, replace the line from:

```

"$ORIGINAL_DIR/target/release/cargo-nexus" nexus run
"$ORIGINAL_DIR/target/release/cargo-nexus" nexus prove
"$ORIGINAL_DIR/target/release/cargo-nexus" nexus verify

```

to

```
FLAMEGRAPH=1 "$ORIGINAL_DIR/target/release/cargo-nexus" nexus run
FLAMEGRAPH=1 "$ORIGINAL_DIR/target/release/cargo-nexus" nexus prove
FLAMEGRAPH=1 "$ORIGINAL_DIR/target/release/cargo-nexus" nexus verify
```
