### PR TITLE
Re-export postcard in runtime

### DIFF
--- a/cli/src/command/host.rs
+++ b/cli/src/command/host.rs
@@ -116,6 +116,18 @@ fn setup_crate(host_path: PathBuf, rev: Option<String>, tag: Option<String>) -> 
         ],
     )?;
 
+    // add postcard because it is used for (de)serializing from/to the input/output tapes
+    cargo(
+        Some(&guest_path),
+        [
+            "add",
+            "postcard@1.0.10",
+            "-F",
+            "alloc",
+            "--no-default-features",
+        ],
+    )?;
+
     let mut fp2 = fs::OpenOptions::new()
         .append(true)
         .open(guest_path.join("Cargo.toml"))?;

--- a/cli/src/command/host.rs
+++ b/cli/src/command/host.rs
@@ -116,19 +116,6 @@ fn setup_crate(host_path: PathBuf, rev: Option<String>, tag: Option<String>) -> 
         ],
     )?;
 
-    // add postcard because it is used for (de)serializing from/to the input/output tapes
-    // Hardcode postcard version to 1.0.8
-    cargo(
-        Some(&guest_path),
-        [
-            "add",
-            "postcard@=1.0.8",
-            "-F",
-            "alloc",
-            "--no-default-features",
-        ],
-    )?;
-
     let mut fp2 = fs::OpenOptions::new()
         .append(true)
         .open(guest_path.join("Cargo.toml"))?;

--- a/examples/src/bin/input_output.rs
+++ b/examples/src/bin/input_output.rs
@@ -1,10 +1,10 @@
 #![cfg_attr(target_arch = "riscv32", no_std, no_main)]
 
-use nexus_rt::{println, read_private_input, write_output};
+use nexus_rt::{Error, println, read_private_input, write_output};
 
 #[nexus_rt::main]
 fn main() {
-    let input = read_private_input::<(u32, u32)>();
+    let input:Result<(u32, u32), Error> = read_private_input::<(u32, u32)>();
 
     let mut z: i32 = -1;
     if let Ok((x, y)) = input {

--- a/examples/src/bin/input_output.rs
+++ b/examples/src/bin/input_output.rs
@@ -4,7 +4,7 @@ use nexus_rt::{Error, println, read_private_input, write_output};
 
 #[nexus_rt::main]
 fn main() {
-    let input:Result<(u32, u32), Error> = read_private_input::<(u32, u32)>();
+    let input: Result<(u32, u32), Error> = read_private_input::<(u32, u32)>();
 
     let mut z: i32 = -1;
     if let Ok((x, y)) = input {

--- a/examples/src/bin/input_output.rs
+++ b/examples/src/bin/input_output.rs
@@ -1,10 +1,10 @@
 #![cfg_attr(target_arch = "riscv32", no_std, no_main)]
 
-use nexus_rt::{Error, println, read_private_input, write_output};
+use nexus_rt::{postcard, println, read_private_input, write_output};
 
 #[nexus_rt::main]
 fn main() {
-    let input: Result<(u32, u32), Error> = read_private_input::<(u32, u32)>();
+    let input: Result<(u32, u32), postcard::Error> = read_private_input::<(u32, u32)>();
 
     let mut z: i32 = -1;
     if let Ok((x, y)) = input {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,7 +11,7 @@ categories = { workspace = true }
 
 [dependencies]
 nexus-rt-macros = { path = "macros", version = "0.1.0" }
-postcard = { version = "1.0.10", features = ["alloc"] }
+postcard = { version = "1.0.10", features = ["alloc"], default_features = false }
 serde = { version = "1.0", default-features = false }
 
 [lib]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,7 +11,7 @@ categories = { workspace = true }
 
 [dependencies]
 nexus-rt-macros = { path = "macros", version = "0.1.0" }
-postcard = { version = "=1.0.8", features = ["alloc"] }
+postcard = { version = "=1.0.10", features = ["alloc"] }
 serde = { version = "1.0", default-features = false }
 
 [lib]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -11,7 +11,7 @@ categories = { workspace = true }
 
 [dependencies]
 nexus-rt-macros = { path = "macros", version = "0.1.0" }
-postcard = { version = "=1.0.10", features = ["alloc"] }
+postcard = { version = "1.0.10", features = ["alloc"] }
 serde = { version = "1.0", default-features = false }
 
 [lib]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -13,4 +13,4 @@ pub use nexus_rt_macros::{main, profile};
 
 mod ecalls;
 pub use ecalls::*;
-pub use postcard::*;
+pub use postcard;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -13,3 +13,4 @@ pub use nexus_rt_macros::{main, profile};
 
 mod ecalls;
 pub use ecalls::*;
+pub use postcard::*;

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -14,7 +14,7 @@ serde.workspace = true
 
 nexus-core = { path = "../core", features = ["prover_nova", "prover_jolt", "prover_hypernova"] }
 nexus-macro = { path = "../macro" }
-postcard = { version = "=1.0.8", features = ["alloc"] }
+postcard = { version = "=1.0.10", features = ["alloc"] }
 uuid = { version = "1.9.1", features = ["v4", "fast-rng"] }
 thiserror = "1.0.61"
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -14,7 +14,7 @@ serde.workspace = true
 
 nexus-core = { path = "../core", features = ["prover_nova", "prover_jolt", "prover_hypernova"] }
 nexus-macro = { path = "../macro" }
-postcard = { version = "1.0.10", features = ["alloc"] }
+postcard = { version = "1.0.10", features = ["alloc"], default_features = false }
 uuid = { version = "1.9.1", features = ["v4", "fast-rng"] }
 thiserror = "1.0.61"
 

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -14,7 +14,7 @@ serde.workspace = true
 
 nexus-core = { path = "../core", features = ["prover_nova", "prover_jolt", "prover_hypernova"] }
 nexus-macro = { path = "../macro" }
-postcard = { version = "=1.0.10", features = ["alloc"] }
+postcard = { version = "1.0.10", features = ["alloc"] }
 uuid = { version = "1.9.1", features = ["v4", "fast-rng"] }
 thiserror = "1.0.61"
 


### PR DESCRIPTION
Re-exports `postcard` in `runtime` crate to ensure consistent serialization between host, guest and prover.

Resolves #277.