### PR TITLE
Add feature-gated partial prove interface

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -46,3 +46,5 @@ parallel = [
 prover_hypernova = ["dep:nexus-nova", "dep:spartan"]
 prover_nova = ["dep:nexus-nova", "dep:spartan"]
 prover_jolt = ["dep:nexus-jolt"]
+
+partial_prove = []

--- a/core/src/prover/hypernova/mod.rs
+++ b/core/src/prover/hypernova/mod.rs
@@ -32,6 +32,7 @@ pub fn init_circuit_trace(trace: Trace) -> Result<SC, ProofError> {
     super::nova::init_circuit_trace(trace).map_err(ProofError::from)
 }
 
+// nb: feature-gated as only relevant for testing
 #[cfg(feature = "partial_prove")]
 pub fn prove_partial_seq(
     pp: &PP,

--- a/core/src/prover/hypernova/mod.rs
+++ b/core/src/prover/hypernova/mod.rs
@@ -32,6 +32,30 @@ pub fn init_circuit_trace(trace: Trace) -> Result<SC, ProofError> {
     super::nova::init_circuit_trace(trace).map_err(ProofError::from)
 }
 
+#[cfg(feature = "partial_prove")]
+pub fn prove_partial_seq(
+    pp: &PP,
+    trace: Trace,
+    start: usize,
+    len: usize,
+) -> Result<IVCProof, ProofError> {
+    let tr = init_circuit_trace(trace)?;
+
+    let end = start + len;
+    if end >= tr.steps() {
+        return Err(ProofError::InvalidIndex(tr.steps()));
+    }
+
+    let z_st = tr.input(start)?;
+    let mut proof = IVCProof::new(&z_st);
+
+    for _ in start..end {
+        proof = prove_seq_step(Some(proof), pp, &tr)?;
+    }
+
+    Ok(proof)
+}
+
 pub fn prove_seq(pp: &PP, trace: Trace) -> Result<IVCProof, ProofError> {
     let tr = init_circuit_trace(trace)?;
 

--- a/core/src/prover/nova/mod.rs
+++ b/core/src/prover/nova/mod.rs
@@ -66,6 +66,30 @@ pub fn init_circuit_trace(trace: Trace) -> Result<SC, ProofError> {
     Ok(tr)
 }
 
+#[cfg(feature = "partial_prove")]
+pub fn prove_partial_seq(
+    pp: &SeqPP,
+    trace: Trace,
+    start: usize,
+    len: usize,
+) -> Result<IVCProof, ProofError> {
+    let tr = init_circuit_trace(trace)?;
+
+    let end = start + len;
+    if end >= tr.steps() {
+        return Err(ProofError::InvalidIndex(tr.steps()));
+    }
+
+    let z_st = tr.input(start)?;
+    let mut proof = IVCProof::new(&z_st);
+
+    for _ in start..end {
+        proof = prove_seq_step(Some(proof), pp, &tr)?;
+    }
+
+    Ok(proof)
+}
+
 pub fn prove_seq(pp: &SeqPP, trace: Trace) -> Result<IVCProof, ProofError> {
     let tr = init_circuit_trace(trace)?;
 

--- a/core/src/prover/nova/mod.rs
+++ b/core/src/prover/nova/mod.rs
@@ -66,6 +66,7 @@ pub fn init_circuit_trace(trace: Trace) -> Result<SC, ProofError> {
     Ok(tr)
 }
 
+// nb: feature-gated as only relevant for testing
 #[cfg(feature = "partial_prove")]
 pub fn prove_partial_seq(
     pp: &SeqPP,


### PR DESCRIPTION
This PR adds a feature-gated partial proof interface that allows generating a proof for a subsequence of a trace.

Intended for use in testing.