### PR TITLE
dense_mlpoly.rs: Fix manipulation of evaluation vector Z by bound functions

### DIFF
--- a/spartan/src/dense_mlpoly.rs
+++ b/spartan/src/dense_mlpoly.rs
@@ -221,7 +221,7 @@ impl<F: PrimeField> DensePolynomial<F> {
     for i in 0..n {
       self.Z[i] = self.Z[i] + *r * (self.Z[i + n] - self.Z[i]);
     }
-    self.Z.truncate(n);  // Resize the vector Z to the new length
+    self.Z.truncate(n); // Resize the vector Z to the new length
     self.num_vars -= 1;
     self.len = n;
   }
@@ -231,7 +231,7 @@ impl<F: PrimeField> DensePolynomial<F> {
     for i in 0..n {
       self.Z[i] = self.Z[2 * i] + *r * (self.Z[2 * i + 1] - self.Z[2 * i]);
     }
-    self.Z.truncate(n);  // Resize the vector Z to the new length
+    self.Z.truncate(n); // Resize the vector Z to the new length
     self.num_vars -= 1;
     self.len = n;
   }

--- a/spartan/src/dense_mlpoly.rs
+++ b/spartan/src/dense_mlpoly.rs
@@ -221,6 +221,7 @@ impl<F: PrimeField> DensePolynomial<F> {
     for i in 0..n {
       self.Z[i] = self.Z[i] + *r * (self.Z[i + n] - self.Z[i]);
     }
+    self.Z.truncate(n);  // Resize the vector Z to the new length
     self.num_vars -= 1;
     self.len = n;
   }
@@ -230,6 +231,7 @@ impl<F: PrimeField> DensePolynomial<F> {
     for i in 0..n {
       self.Z[i] = self.Z[2 * i] + *r * (self.Z[2 * i + 1] - self.Z[2 * i]);
     }
+    self.Z.truncate(n);  // Resize the vector Z to the new length
     self.num_vars -= 1;
     self.len = n;
   }


### PR DESCRIPTION
The bound functions were folding the `Z` vector on itself but were not actually truncating it (even though they were changing `self.len`).

Hence, if you called a bound function and then `evaluate()` it would assert because `evaluate()` checks the size of the `Z` vector.