### PR TITLE
Update network docs

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -93,7 +93,7 @@ To get started with the Nexus zkVM, check out the [SDK Quick Start](zkvm/sdk-qui
 
 The ethos of the Nexus project is a commitment to open and transparent science, engineering, and evaluation.
 
-For an in-depth look at the science behind the Nexus zkVM and the Nexus Network, see the [Nexus Whitepaper](https://nexus-xyz.github.io/assets/nexus_whitepaper.pdf).
+For an in-depth look at the science behind the Nexus zkVM and the Nexus network, see the [Nexus Whitepaper](https://nexus-xyz.github.io/assets/nexus_whitepaper.pdf).
 
 ### Core Components
 
@@ -118,9 +118,9 @@ The zkVM aims to offer developers out-of-the-box prover performance and security
 
 The Nexus zkVM turns programs into proofs, but the computational work of executing and proving the zkVM must be implemented by a proving architecture.
 
-The Nexus zkVM design is compatible with a variety of proving architectures, from sequential execution on your laptop all the way up to the [Nexus Network](network.mdx), a globally-distributed proving network under active development.
+The Nexus zkVM design is compatible with a variety of proving architectures, from sequential execution on your laptop all the way up to the [Nexus network](network.mdx), a globally-distributed proving network under active development.
 
-See the [Nexus Network](network.mdx) overview for more.
+See the [Nexus network](network.mdx) overview for more.
 
 ## The Nexus Ethos: Secure, Open Science, Open Source
 

--- a/docs/pages/network.mdx
+++ b/docs/pages/network.mdx
@@ -23,7 +23,7 @@ import { Callout } from 'nextra/components'
 
 The Nexus network is a massively-parallelized proof network for executing and proving the Nexus zkVM.
 
-* [Network Documentation](https://nexus.xyz/network#network-faqs)
+* [Network documentation](https://nexus.xyz/network#network-faqs)
 * [Run a Nexus prover from your browser](https://beta.nexus.xyz/)
-* [Install the network CLI](https://github.com/nexus-xyz/network-api/blob/main/clients/cli/README.md)
+* [Network CLI](https://github.com/nexus-xyz/network-api/blob/main/clients/cli/README.md)
 * [Release notes](https://github.com/nexus-xyz/network-api/releases/)

--- a/docs/pages/network.mdx
+++ b/docs/pages/network.mdx
@@ -30,4 +30,4 @@ The Nexus network is a massively-parallelized proof network for executing and pr
 * [Network Documentation](https://nexus.xyz/network#network-faqs)
 * [Run a Nexus prover from your browser](https://beta.nexus.xyz/)
 * [Install the network CLI](https://github.com/nexus-xyz/network-api/blob/main/clients/cli/README.md)
-* [Notes about the latest release](https://github.com/nexus-xyz/network-api/releases/)
+* [Release notes](https://github.com/nexus-xyz/network-api/releases/)

--- a/docs/pages/network.mdx
+++ b/docs/pages/network.mdx
@@ -23,10 +23,6 @@ import { Callout } from 'nextra/components'
 
 The Nexus network is a massively-parallelized proof network for executing and proving the Nexus zkVM.
 
-<Callout type="info" emoji="ℹ️">
-  The Nexus network is currently in a beta stage.
-</Callout>
-
 * [Network Documentation](https://nexus.xyz/network#network-faqs)
 * [Run a Nexus prover from your browser](https://beta.nexus.xyz/)
 * [Install the network CLI](https://github.com/nexus-xyz/network-api/blob/main/clients/cli/README.md)

--- a/docs/pages/network.mdx
+++ b/docs/pages/network.mdx
@@ -13,49 +13,21 @@ import { Callout } from 'nextra/components'
 <br />
 
 <div style={{display: "flex"}}>
-    <a href="https://t.me/nexus_zkvm" style={{marginRight: 3}}>
-        <img src="https://img.shields.io/endpoint?color=neon&logo=telegram&label=chat&url=https%3A%2F%2Fmogyo.ro%2Fquart-apis%2Ftgmembercount%3Fchat_id%3Dnexus_zkvm"/>
-    </a>
-    <a href="https://github.com/nexus-xyz/nexus-zkvm/graphs/contributors" style={{marginRight: 3}}>
-        <img src="https://img.shields.io/github/contributors/nexus-xyz/nexus-zkvm.svg"/>
-    </a>
     <a href="https://twitter.com/NexusLabsHQ" style={{marginRight: 3}}>
         <img src="https://img.shields.io/badge/Twitter-black?logo=x&logoColor=white"/>
     </a>
-    <a href="https://nexus.xyz" style={{marginRight: 3}}>
-        <img src="https://img.shields.io/static/v1?label=Stage&message=Alpha&color=2BB4AB"/>
-    </a>
-    <a href="https://github.com/nexus-xyz/nexus-zkvm/blob/main/LICENSE-MIT" style={{marginRight: 3}}>
-        <img src="https://img.shields.io/badge/license-MIT-blue"/>
-    </a>
-    <a href="https://github.com/nexus-xyz/nexus-zkvm/blob/main/LICENSE-APACHE" style={{marginRight: 3}}>
-        <img src="https://img.shields.io/badge/license-APACHE-blue"/>
+    <a href="https://nexus.xyz/network" style={{marginRight: 3}}>
+        <img src="https://img.shields.io/static/v1?label=Stage&message=Beta&color=2BB4AB"/>
     </a>
 </div>
 
-The Nexus Network is a massively-parallelized proof network for executing and proving the Nexus zkVM.
-
-[Nexus Network v0.2.3](https://github.com/nexus-xyz/nexus-zkvm/releases/tag/v0.2.3) is the current stable release, implementing the network component of the Nexus 2.0 system.
+The Nexus network is a massively-parallelized proof network for executing and proving the Nexus zkVM.
 
 <Callout type="info" emoji="ℹ️">
-  The Nexus Network is currently in a prototype stage.
+  The Nexus network is currently in a beta stage.
 </Callout>
 
-
-## A Global Network
-
-> A world-scale zkVM supercomputer.
-
-<br />
-
-<p align="center" >
-    <Image alt="Nexus zkVM" src = "/images/nexus_docs-network.png" width = {800} height = {800} />
-</p>
-
-The global Nexus Network is designed to run at over a trillion CPU cycles per second given enough computing power connected to it, creating a world-scale supercomputer with the capacity to prove many of the world's most important computations quickly and correctly.
-
-### Proving with Privacy and Reliability
-
-Many practical applications have high requirements for privacy of data and trust in the compute infrastructure that handles it. The Nexus Network is also being designed to flexibly support configurations providing stronger privacy guarantees for the most critical application domains.
-
-Stay tuned for more...
+* [Network Documentation](https://nexus.xyz/network#network-faqs)
+* [Run a Nexus prover from your browser](https://beta.nexus.xyz/)
+* [Install the network CLI](https://github.com/nexus-xyz/network-api/blob/main/clients/cli/README.md)
+* [Notes about the latest release](https://github.com/nexus-xyz/network-api/releases/)


### PR DESCRIPTION
Updates network documentation to point to [network-api](https://github.com/nexus-xyz/network-api/) repository and [network FAQ](https://nexus.xyz/network). 