### PR TITLE
Fix typo on sdk-quick-start.mdx

### DIFF
--- a/docs/pages/zkvm/sdk-quick-start.mdx
+++ b/docs/pages/zkvm/sdk-quick-start.mdx
@@ -216,6 +216,6 @@ fn main() {
 }
 ```
 
-To see more example of using the SDK, check out [the examples folder](https://github.com/nexus-xyz/nexus-zkvm/tree/main/sdk/examples).
+To see more examples of using the SDK, check out [the examples folder](https://github.com/nexus-xyz/nexus-zkvm/tree/main/sdk/examples).
 
 </Steps>


### PR DESCRIPTION
```
< example
---
> examples
```