### PR TITLE
Fix: documentation typos in multiple files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ There are three main ways to contribute:
 If you have reviewed this document and existing documentation and still have questions or are still having problems, but don't quite know enough to create a bug report, then 
 you can get help by **starting a discussion**. 
 
-You can do so either on the [dev Telegram][dev-tg] or on discussiom board of the [Github][gh] page for this repository. Look for the "Discussions" tab at the top.
+You can do so either on the [dev Telegram][dev-tg] or on discussion board of the [Github][gh] page for this repository. Look for the "Discussions" tab at the top.
 
 #### Submitting a bug report
 

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -7,7 +7,7 @@ functions for accessing VM built-ins, such as `write_log`.
 ## Getting Started
 
 First, you will need a rust compiler with the RISC-V target
-installed.  If you do no have the RISC-V target installed,
+installed.  If you do not have the RISC-V target installed,
 you can install it with `rustup`:
 
 ```
@@ -64,14 +64,14 @@ against the `std` crate, and that we do not want the
 compiler to emit the standard start-up code to process
 command-line arguments and call `main`. The Nexus Runtime
 has a minimal start-up process and will call your entry
-function directly.  The fourth line brings the nexux-rt
+function directly.  The fourth line brings the nexus-rt
 `entry` macro into scope.  This macro is used to mark the
 `main` function as the starting point of the program.
 
 To run your program, you can use either the `cargo-nexus`,
 or the `nexus-riscv` crate. The `cargo-nexus` uses the
 `nexus-riscv` crate internally. To use the `nexus-riscv`
-crate, compile the crate and use the included commend-line
+crate, compile the crate and use the included command-line
 tool:
 
 ```

--- a/spartan/README.md
+++ b/spartan/README.md
@@ -81,7 +81,7 @@ Some of our public APIs' style is inspired by the underlying crates we use.
     let SRS = Hyrax::<G1Projective>::setup(min_num_vars, b"example_SRS", &mut test_rng()).unwrap();
     let gens = SNARKGens::<G1Projective, Hyrax<G1Projective>>::new(&SRS, num_cons, num_vars, num_inputs, num_non_zero_entries);
 
-    // ask the library to produce a synthentic R1CS instance
+    // ask the library to produce a synthetic R1CS instance
     let (inst, vars, inputs) = Instance::produce_synthetic_r1cs(num_cons, num_vars, num_inputs);
 
     // create a commitment to the R1CS instance
@@ -118,7 +118,7 @@ Here is another example to use the NIZK variant of the Spartan proof system:
     // produce public parameters
     let gens = NIZKGens::<G1Projective>::new(num_cons, num_vars, num_inputs);
 
-    // ask the library to produce a synthentic R1CS instance
+    // ask the library to produce a synthetic R1CS instance
     let (inst, vars, inputs) = Instance::<Fr>::produce_synthetic_r1cs(num_cons, num_vars, num_inputs);
 
     // produce a proof of satisfiability
@@ -216,7 +216,7 @@ Finally, we provide an example that specifies a custom R1CS instance instead of 
   let mut C: Vec<(usize, usize, Fr)> = Vec::new();
 
   // The constraint system is defined over a finite field, which in our case is
-  // the scalar field of ristreeto255/curve25519 i.e., p =  2^{252}+27742317777372353535851937790883648493
+  // the scalar field of ristretto255/curve25519 i.e., p =  2^{252}+27742317777372353535851937790883648493
   // To construct these matrices, we will use `curve25519-dalek` but one can use any other method.
 
   // a variable that holds a byte representation of 1


### PR DESCRIPTION
This pull request addresses and fixes various typographical errors in the project's documentation files:

- **CONTRIBUTING.md**:  
  Corrected "discussiom" to "discussion" for better clarity.

- **runtime/README.md**:  
  Fixed typos such as:
  - "do no" → "do not"
  - "nexux-rt" → "nexus-rt"
  - "commend-line" → "command-line"

- **spartan/README.md**:  
  Resolved the following typos:
  - "synthentic" → "synthetic"
  - "ristreeto255" → "ristretto255"
