### PR TITLE
docs: typo fix Update nexus-memory-checking.mdx

### DIFF
--- a/docs/pages/specs/nexus-memory-checking.mdx
+++ b/docs/pages/specs/nexus-memory-checking.mdx
@@ -13,7 +13,7 @@ In order to enforce the consistency of read-write operations into the memory, th
 
 ### Merkle Tree Setup
 
-In the current version of Nexus VM, the memory size is set to $\mathbf{2^{22}}$ bytes. Hence, we associate leafs to 256-bit-long strings (i.e., 32 bytes) and then use a Merkle binary tree with 17 levels to describe its contents, as in the figure below.
+In the current version of Nexus VM, the memory size is set to $\mathbf{2^{22}}$ bytes. Hence, we associate leaves to 256-bit-long strings (i.e., 32 bytes) and then use a Merkle binary tree with 17 levels to describe its contents, as in the figure below.
 
 ![merkle-hash-tree](/images/merkle-hash-tree.svg)
 


### PR DESCRIPTION
In the documentation file docs/pages/specs/nexus-memory-checking.mdx, the term "leafs" was used to describe elements of a tree structure. However, the correct term to use in this context is "**leaves**."

Corrected.