### PR TITLE
Fix Typos

### DIFF
--- a/spartan/README.md
+++ b/spartan/README.md
@@ -77,7 +77,7 @@ Some of our public APIs' style is inspired by the underlying crates we use.
 
     // produce public parameters
     let min_num_vars = SNARKGens::<G1Projective, Hyrax<G1Projective>>::get_min_num_vars(num_cons, num_vars, num_inputs, num_non_zero_entries);
-    // derive a SRS for the polynomial commitment scheme
+    // derive an SRS for the polynomial commitment scheme
     let SRS = Hyrax::<G1Projective>::setup(min_num_vars, b"example_SRS", &mut test_rng()).unwrap();
     let gens = SNARKGens::<G1Projective, Hyrax<G1Projective>>::new(&SRS, num_cons, num_vars, num_inputs, num_non_zero_entries);
 

--- a/spartan/SECURITY.md
+++ b/spartan/SECURITY.md
@@ -12,7 +12,7 @@ If you believe you have found a security vulnerability in any Microsoft-owned re
 
 Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
 
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc).
 


### PR DESCRIPTION
This pull request addresses minor typographical errors in the `README.md` and `SECURITY.md` files in the `spartan` directory:  

1. **README.md**:  
   - Corrected the usage of "a" to "an" in the phrase "derive an SRS for the polynomial commitment scheme."  

2. **SECURITY.md**:  
   - Removed the duplicate "the" in "download it from the the Microsoft Security Response Center PGP Key page."  

These changes improve the clarity and correctness of the documentation.  
