### PR TITLE
fix:  Improve string formatting for better readability Update network.rs

### DIFF
--- a/config/src/network.rs
+++ b/config/src/network.rs
@@ -32,7 +32,7 @@ impl fmt::Display for ClientConfig {
             .map(|port| [":", &port.to_string()].concat())
             .unwrap_or_default();
 
-        write!(f, "{hostname}{port}")
+        write!(f, "{}{}", hostname, port)
     }
 }
 


### PR DESCRIPTION
#### Describe your changes.

In the current implementation, the formatting for strings in `fmt::Display` is done using the following syntax:

```rust
write!(f, "{hostname}{port}")
```

While this syntax works correctly, it can be improved for better readability and clarity. The revised approach uses a more conventional and straightforward method of formatting:

```rust
write!(f, "{}{}", hostname, port)
```

This change doesn't affect functionality but makes the code easier to read and maintain, following a more common formatting style in Rust.