### PR TITLE
Fix error message in instruction parsing Update parse.rs

### DIFF
--- a/jolt/src/parse.rs
+++ b/jolt/src/parse.rs
@@ -73,7 +73,7 @@ fn parse_instructions(elf: &ElfBytes<LittleEndian>, data: &[u8]) -> Result<Vec<I
                     target: LOG_TARGET,
                     ?addr,
                     error = ?err,
-                    "Failed to pass the instruction",
+                    "Failed to parse the instruction",
                 );
                 Inst {
                     pc: addr as u32,


### PR DESCRIPTION
#### Describe your changes.

Issue in the error handling message within the `parse_inst` method. The original message incorrectly referred to "passing" the instruction. This could cause confusion, as the method is responsible for **parsing** instructions, not passing them.

#### The original message:
```rust
"Failed to pass the instruction",
```

#### The corrected message:
```rust
"Failed to parse the instruction",
```

This change ensures the error message aligns with the method's actual functionality and avoids confusion during debugging.

---

This update clarifies the purpose of the error message and improves the overall developer experience when troubleshooting.