### PR TITLE
fix: Refactor error handling to leverage thiserror's automatic Displa…

### DIFF
--- a/sdk/src/error.rs
+++ b/sdk/src/error.rs
@@ -1,10 +1,10 @@
-use std::fmt::Display;
 use thiserror::Error;
 
 /// Errors that occur during dynamic compilation of guest programs.
 #[derive(Debug, Error)]
 pub enum BuildError {
     /// The compile options are invalid for the memory limit.
+    #[error("invalid memory configuration for selected prover")]
     InvalidMemoryConfiguration,
 
     /// An error occurred reading or writing to the file system.
@@ -12,53 +12,26 @@ pub enum BuildError {
     IOError(#[from] std::io::Error),
 
     /// The compilation process failed.
+    #[error("unable to compile using rustc")]
     CompilerError,
-}
-
-impl Display for BuildError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::InvalidMemoryConfiguration => {
-                write!(f, "invalid memory configuration for selected prover")
-            }
-            Self::IOError(error) => write!(f, "{}", error),
-            Self::CompilerError => write!(f, "unable to compile using rustc"),
-        }
-    }
 }
 
 /// Errors that occur while reading from or writing to the input/output tapes of the zkVM.
 #[derive(Debug, Error)]
 pub enum TapeError {
     /// Error serializing to or deserializing from the zkVM input/output tapes.
+    #[error("serialization error: {0}")]
     SerializationError(#[from] postcard::Error),
 
     /// Error parsing logging tape.
+    #[error("encoding error: {0}")]
     EncodingError(#[from] std::string::FromUtf8Error),
 }
 
-impl Display for TapeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::SerializationError(error) => write!(f, "{}", error),
-            Self::EncodingError(error) => write!(f, "{}", error),
-        }
-    }
-}
-
+/// Errors that occur when processing file paths.
 #[derive(Debug, Error)]
 pub enum PathError {
     /// Invalid encoding used for path.
+    #[error("provided path has invalid encoding for use with filesystem")]
     EncodingError,
-}
-
-impl Display for PathError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::EncodingError => write!(
-                f,
-                "provided path has invalid encoding for use with filesystem"
-            ),
-        }
-    }
 }


### PR DESCRIPTION
This update simplifies error handling by removing the manual implementation of the `Display` trait and relying on `thiserror`'s capabilities to automatically generate it.  

---

### **What has been changed?**  
- Removed the manual `Display` implementations for all error enums.  
- Added the `#[error(...)]` attribute to each error variant to define error descriptions directly.  
- Ensured that `#[from]` is properly used for error conversions, reducing boilerplate code.  

---

### **Why is this better?**  
- `thiserror` automatically implements the `Display` trait, ensuring consistency and simplifying error handling.  
- The code is now cleaner and free from unnecessary boilerplate.  
- Error descriptions are explicitly defined using `#[error(...)]`, making the code easier to read and maintain.  
- The implementation now adheres to best practices for error handling with `thiserror`.  

---

This refactor not only simplifies the code but also ensures that all errors are formatted and handled in an idiomatic way.