### PR TITLE
Update Nexus zkVM installation command in README

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -19,7 +19,7 @@ rustup target add riscv32i-unknown-none-elf
 Then, install the Nexus zkVM:
 
 ```shell
-cargo install --git https://github.com/nexus-xyz/nexus-zkvm cargo-nexus --tag 'v0.2.0'
+cargo install --git https://github.com/nexus-xyz/nexus-zkvm cargo-nexus --tag 'v0.2.4'
 ```
 
 Verify the installation:


### PR DESCRIPTION
This pull request updates the Nexus zkVM installation command in the `sdk/README.md` file to ensure it works as intended. The change aligns the command with the correct syntax for seamless installation.