### PR TITLE
refactor: improve error handling in R1CS gadgets

### DIFF
--- a/nova/src/gadgets/cyclefold/nova/primary.rs
+++ b/nova/src/gadgets/cyclefold/nova/primary.rs
@@ -87,8 +87,10 @@ where
 
         let r1cs = f()?;
         let X = &r1cs.borrow().X;
-        // Only allocate valid instance, which starts with F::ONE.
-        assert_eq!(X[0], G1::ScalarField::ONE);
+        
+        if X[0] != G1::ScalarField::ONE {
+            return Err(SynthesisError::Unsatisfiable);
+        }
 
         let commitment_W = EmulatedFpAffineVar::new_variable(
             cs.clone(),
@@ -117,7 +119,7 @@ where
     C1: CommitmentScheme<Projective<G1>>,
 {
     fn to_sponge_bytes(&self) -> Result<Vec<UInt8<G1::ScalarField>>, SynthesisError> {
-        unreachable!()
+        Err(SynthesisError::Unsatisfiable)
     }
 
     fn to_sponge_field_elements(&self) -> Result<Vec<FpVar<G1::ScalarField>>, SynthesisError> {
@@ -259,7 +261,7 @@ where
     C1: CommitmentScheme<Projective<G1>>,
 {
     fn to_sponge_bytes(&self) -> Result<Vec<UInt8<G1::ScalarField>>, SynthesisError> {
-        unreachable!()
+        Err(SynthesisError::Unsatisfiable)
     }
 
     fn to_sponge_field_elements(&self) -> Result<Vec<FpVar<G1::ScalarField>>, SynthesisError> {


### PR DESCRIPTION
Before opening your pull request, please respond to the following prompts.

#### Is this resolving a feature or a bug?

This PR addresses code robustness improvements, particularly in the error handling patterns used within the codebase.

#### Are there existing issue(s) that this PR would close?
No specific issues are closed with this PR, but it improves the overall error handling and robustness, which may resolve any future issues related to panics or unhandled errors in the affected parts of the code.
#### If this PR is not minimal (it could be split into multiple PRs), please explain why the issues are best resolved together. 
This PR is minimal, as it focuses on replacing specific error handling patterns (e.g., unreachable!() and assertions) with more robust and maintainable alternatives. These changes are logically related and necessary to apply together to ensure consistent error handling across the affected areas.
#### Describe your changes.
- Replace unreachable!() with proper error handling in AbsorbGadget implementations
- Convert assertion to Result-based error handling in R1CSInstanceVar