### PR TITLE
Update verify.rs

### DIFF
--- a/cli/src/command/verify.rs
+++ b/cli/src/command/verify.rs
@@ -177,7 +177,7 @@ fn verify_proof(
         }
     }
     .to_str()
-    .context("path is not utf8")?
+    .context("path is not utf-8")?
     .to_owned();
 
     let mut term = TerminalHandle::new_enabled();


### PR DESCRIPTION
This change standardizes the UTF-8 encoding string format throughout the codebase. The hyphenated form "utf-8" is the official and more widely used format according to Unicode specifications. The rest of the codebase already uses the hyphenated form "utf-8", so this change brings consistency to the error messages.
