### PR TITLE
Update rust.yml

### DIFF
--- a/spartan/.github/workflows/rust.yml
+++ b/spartan/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
   build_nightly:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install
       run: rustup default nightly
     - name: Install rustfmt Components


### PR DESCRIPTION
Update actions/checkout from v2 to v4 in Spartan workflow

Changes Made:
spartan/.github/workflows/rust.yml:
- uses: actions/checkout@v2
+ uses: actions/checkout@v4

Why:
- Improves performance and security
- Adds better support for modern Git features
- Aligns with other workflows that already use v4
- Follows GitHub Actions best practices

All other workflows in the repository are already using checkout@v4, making this change consistent across the codebase.