### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
         <img src="https://img.shields.io/endpoint?color=neon&logo=telegram&label=chat&url=https%3A%2F%2Fmogyo.ro%2Fquart-apis%2Ftgmembercount%3Fchat_id%3Dnexus_zkvm"/></a>
     <a href="https://github.com/nexus-xyz/nexus-zkvm/graphs/contributors">
         <img src="https://img.shields.io/github/contributors/nexus-xyz/nexus-zkvm.svg"></a>
-    <a href="https://twitter.com/NexusLabsHQ">
+    <a href="https://x.com/NexusLabsHQ">
         <img src="https://img.shields.io/badge/Twitter-black?logo=x&logoColor=white"/></a>
     <a href="https://nexus.xyz">
         <img src="https://img.shields.io/static/v1?label=Stage&message=Alpha&color=2BB4AB"/></a>


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.
