### PR TITLE
fix: fix incorrect usage of OutputSize::INT in HashBytes

### DIFF
--- a/network/rpc/common/src/hash.rs
+++ b/network/rpc/common/src/hash.rs
@@ -11,7 +11,7 @@ use sha3::{
 /// Prefixes the program bytes when computing hash.
 pub const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-type HashBytes = [u8; <Sha3_256Core as OutputSizeUser>::OutputSize::INT];
+type HashBytes = [u8; <Sha3_256Core as OutputSizeUser>::OutputSize::USIZE];
 /// Hash type.
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Hash(#[serde(with = "hex::serde")] pub HashBytes);


### PR DESCRIPTION
#### Is this resolving a feature or a bug?  
This fixes a bug where `OutputSize::INT` was incorrectly used instead of `OutputSize::USIZE`.  

#### Are there existing issue(s) that this PR would close?  
No known open issues, but this corrects a potential type mismatch.  

#### If this PR is not minimal (it could be split into multiple PRs), please explain why the issues are best resolved together.  
This is a single, self-contained fix that does not require further splitting.  

#### Describe your changes.  
Replaced `OutputSize::INT` with `OutputSize::USIZE` in `HashBytes`. Since `OutputSize` is already a `typenum` constant (e.g., `U32`), using `ToInt` was unnecessary. `USIZE` ensures proper conversion to `usize` and avoids potential compilation issues.