### PR TITLE
fix: fix redundant path in error message

### DIFF
--- a/sdk/examples/hypernova.rs
+++ b/sdk/examples/hypernova.rs
@@ -16,7 +16,7 @@ fn main() {
         panic!(
             "{}{} was not found, make sure to compile the program \
              with `cd examples && cargo build --release --bin {}`",
-            "target/riscv32i-unknown-none-elf/release/", EXAMPLE_NAME, EXAMPLE_NAME,
+            path.display(), EXAMPLE_NAME,
         );
     }
 


### PR DESCRIPTION
#### Is this resolving a feature or a bug?  
This is neither a feature nor a bug fix, but a small improvement to the clarity and simplicity of an error message.  

#### Are there existing issue(s) that this PR would close?  
No, this is not tied to any existing issues.  

#### If this PR is not minimal (it could be split into multiple PRs), please explain why the issues are best resolved together.  
This PR is minimal and focuses solely on improving the error message.  

#### Describe your changes.  
In the error message for file path not found, the path `"target/riscv32i-unknown-none-elf/release/"` was being duplicated unnecessarily since it’s already included in `TARGET_PATH`. I updated the `panic!` statement to use `path.display()`, which directly provides the full path in the error message, making it more concise and informative. This eliminates redundancy and improves readability.