### PR TITLE
fix: Fixed let-else syntax issue with correct if-let handling

### DIFF
--- a/jolt/src/trace.rs
+++ b/jolt/src/trace.rs
@@ -92,11 +92,12 @@ fn update_row_post_eval<M: Memory>(
     }
     if let Some((lop, store_addr)) = store_addr {
         let new_value = vm.mem.load(lop, store_addr).expect("invalid store").0 as u64;
-        let Some(jolt_rv::MemoryState::Write { post_value, .. }) = &mut rv_trace_row.memory_state
-        else {
+
+        if let Some(jolt_rv::MemoryState::Write { post_value, .. }) = &mut rv_trace_row.memory_state {
+            *post_value = new_value;
+        } else {
             panic!("invalid memory state for store instruction");
-        };
-        *post_value = new_value;
+        }
     }
 }
 


### PR DESCRIPTION
#### Is this resolving a feature or a bug?  
This resolves a bug related to the use of unstable `let-else` syntax, which causes issues with destructuring references and may be incompatible with older Rust versions.

#### Are there existing issue(s) that this PR would close?  
Yes, this would address compatibility issues caused by the unstable `let-else` syntax in older Rust versions.

#### If this PR is not minimal (it could be split into multiple PRs), please explain why the issues are best resolved together.  
This fix addresses a specific syntax issue, and it is best handled in a single change to ensure stability across versions of Rust.

#### Describe your changes.  
I’ve replaced the unstable `let-else` syntax with a standard `if let` statement that correctly handles destructuring references (`&mut`), ensuring compatibility with all Rust versions. This fixes the original issue and eliminates potential instability.