### PR TITLE
chore: fixed wrong `array` import

### DIFF
--- a/prover/src/chips/instructions/bit_op.rs
+++ b/prover/src/chips/instructions/bit_op.rs
@@ -1,4 +1,4 @@
-use std::array;
+use core::array; 
 
 use num_traits::Zero;
 use stwo_prover::{


### PR DESCRIPTION
#### Is this resolving a feature or a bug?  
Bug.  

#### Are there existing issue(s) that this PR would close?  
No.  

#### If this PR is not minimal (it could be split into multiple PRs), please explain why the issues are best resolved together.  
It's a simple fix, no need to split.  

#### Describe your changes.  
Replaced `std::array` with `core::array`—the correct module in Rust.  