### PR TITLE
chore: fixed broken links

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -68,7 +68,7 @@ function directly. The fourth line brings the nexux-rt
 `main` function as the starting point of the program.
 
 To see more, such as how to introduce program i/o, precompiles,
-and native compilation support, check out our [documentation](https://docs.nexus.xyz).
+and native compilation support, check out our [documentation](https://docs.nexus.xyz/zkvm/index).
 
 ## Crate Overview
 #### Execution flow

--- a/runtime/README.md
+++ b/runtime/README.md
@@ -68,7 +68,7 @@ function directly. The fourth line brings the nexux-rt
 `main` function as the starting point of the program.
 
 To see more, such as how to introduce program i/o, precompiles,
-and native compilation support, check out our [documentation](docs.nexus.xyz).
+and native compilation support, check out our [documentation](https://docs.nexus.xyz).
 
 ## Crate Overview
 #### Execution flow

--- a/vm/src/riscv/instructions/instruction.rs
+++ b/vm/src/riscv/instructions/instruction.rs
@@ -5,9 +5,9 @@
 //! various RISC-V instruction formats.
 //!
 //! References:
-//! - <https://github.com/riscv/riscv-opcodes/blob/master/rv32_i>
-//! - <https://github.com/riscv/riscv-opcodes/blob/master/rv_i>
-//! - <https://github.com/riscv/riscv-opcodes/blob/master/rv_m>
+//! - <https://github.com/riscv/riscv-opcodes/blob/master/extensions/rv32_i>
+//! - <https://github.com/riscv/riscv-opcodes/blob/master/extensions/rv_i>
+//! - <https://github.com/riscv/riscv-opcodes/blob/master/extensions/rv_m>
 
 use crate::riscv::instructions::macros::{
     impl_b_type_instructions, impl_i_type_instructions, impl_i_type_shamt_instructions,


### PR DESCRIPTION
#### Is this resolving a feature or a bug?

Hi! I resolves bugs related to broken links and improves the overall quality of the documentation by ensuring all links are functional and properly formatted.

#### Are there existing issue(s) that this PR would close?
- No existing issues are being closed by this PR.

#### If this PR is not minimal (it could be split into multiple PRs), please explain why the issues are best resolved together. 
- The changes are related to documentation and formatting.

#### Describe your changes.
1. `runtime/README.md`:
   - Fixed the broken documentation link by adding the https:// protocol.

2. `vm/src/riscv/instructions/instruction.rs`:
   - Updated the links to the RISC-V opcodes to point to the correct locations in the riscv-opcodes repository.