### PR TITLE
Restore Missing Permission for CLA Bot

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,5 +1,7 @@
 name: "CLA Assistant"
 on:
+  issue_comment:
+    types: [created]
   pull_request_target:
     types: [opened,closed,synchronize]
 


### PR DESCRIPTION
Fixing an issue with https://github.com/nexus-xyz/nexus-zkvm/pull/376, I accidentally dropped a permission when setting up the configuration.