### PR TITLE
Fix broken SDK docs link 

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -162,4 +162,4 @@ To review the code used in the legacy mode, it corresponds to the [Nexus zkVM v0
 
 ## Learn More
 
-See our zkVM documentation, including guides and walkthroughs, at [docs.nexus.xyz](https://docs.nexus.xyz/zkvm/index). Our SDK package documentation can be viewed at [sdk-docs.nexus.xyz](https://sdk-docs.nexus.xyz).
+See our zkVM documentation, including guides and walkthroughs, at [docs.nexus.xyz](https://docs.nexus.xyz/zkvm/index). Our SDK package documentation can be viewed at [sdk-docs.nexus.xyz](https://sdk-docs.nexus.xyz/doc/nexus_sdk/index.html).


### PR DESCRIPTION
Replaced outdated link https://sdk-docs.nexus.xyz which leads to a blank placeholder page with a more specific and functional one:
🔗 https://sdk-docs.nexus.xyz/doc/nexus_sdk/index.html

📌 Reason:
The previous link only showed a placeholder ("Go to SDK docs") and did not provide actual documentation. The updated link leads directly to the SDK reference and guides.

📷 Screenshot (for reference):
<img width="1506" alt="Знімок екрана 2025-03-31 о 11 59 23" src="https://github.com/user-attachments/assets/345d2b4e-06ec-43a5-913b-b29a6b76c683" />
