### PR TITLE
docs: fix typos in documentation

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -7,16 +7,16 @@ accessing VM built-ins, such as program i/o and debug printing.
 ## Getting Started
 
 First, you will need a rust compiler with the RISC-V target
-installed.  If you do no have the RISC-V target installed,
+installed.  If you do not have the RISC-V target installed,
 you can install it with `rustup`:
 
 ```
 rustup target add riscv32i-unknown-none-elf
 ```
 
-Once your compiler is setup, the easiest way to start a new
+Once your compiler is set up, the easiest way to start a new
 project is to install the `cargo-nexus` crate, and use the
-`cargo nexus new` command. You can also setup your new
+`cargo nexus new` command. You can also set up your new
 project manually as described below.
 
 To start, you will need to create a new project and add the
@@ -63,7 +63,7 @@ against the `std` crate, and that we do not want the
 compiler to emit the standard start-up code to process
 command-line arguments and call `main`. The Nexus runtime
 has a minimal start-up process and will call your entry
-function directly. The fourth line brings the nexux-rt
+function directly. The fourth line brings the nexus-rt
 `entry` macro into scope. This macro is used to mark the
 `main` function as the starting point of the program.
 


### PR DESCRIPTION

Noticed a typos while reading through the docs, so I went ahead and fixed them. Just minor wording fixes to improve clarity.  

#### Is this resolving a feature or a bug?  
This fixes documentation typos, so it's more of a small improvement rather than a bug fix.  

#### Are there existing issue(s) that this PR would close?  
No, I didn’t see an open issue for these typos.  

#### If this PR is not minimal (it could be split into multiple PRs), please explain why the issues are best resolved together.  
Since all changes are minor typo fixes in the same document, it makes sense to keep them together in one update.  

#### Describe your changes.  
- "If you do **no** have the RISC-V target installed" → "If you do **not** have the RISC-V target installed"  
- "Once your compiler is **setup**" → "Once your compiler is **set up**"  
- "You can also **setup** your new project manually" → "You can also **set up** your new project manually"  
- "The fourth line brings the **nexux-rt** entry macro into scope" → "The fourth line brings the **nexus-rt** entry macro into scope"  
