### PR TITLE
Fix broken profiler link 

### DIFF
--- a/sdk/macros/README.md
+++ b/sdk/macros/README.md
@@ -32,7 +32,7 @@ To use `#[profile]` macro in SDK, one must import the profiler dependency:
 
 ```toml
 [dependencies]
-nexus-profiler = { git = "https://github.com/nexus-xyz/nexus-zkvm/macro/profiler" }
+nexus-profiler = { git = "https://github.com/nexus-xyz/nexus-zkvm/tree/main/sdk/macros/profiler" }
 ```
 
 ```rust


### PR DESCRIPTION
The previous link referenced a non-existent or outdated path (/macro/profiler) which would result in a 404 or lead to confusion. The updated link accurately reflects the current file structure within the repository (/tree/main/sdk/macros/profiler), ensuring clarity and proper redirection for users seeking to include the profiler dependency.