### PR TITLE
Fix incorrect guest program path

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -52,7 +52,7 @@ This will create a new Rust project directory with the following structure:
             └── main.rs
 ```
 
-Here, `./src/main.rs` is our host program, while `./src/guest/src/main.rs` is our guest program.
+Here, `./src/main.rs` is our host program, while `./examples/src/main.rs` is our guest program.
 
 As a slightly more interesting example than the default Hello, World! program, you can change the content of `./src/guest/src/main.rs` to:
 


### PR DESCRIPTION
The old path does not exist in the current repo structure, which may confuse new users. The new path points to the actual guest program used in the examples directory.

If there's a more appropriate or canonical guest path to reference, feel free to suggest it — I’ll be happy to update the PR.
