### PR TITLE
docs: correct file name in project structure for Rust config file

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -41,7 +41,7 @@ This will create a new Rust project directory with the following structure:
 ```shell
 ./nexus-host
 ├── Cargo.lock
-├── Cargo.tom
+├── Cargo.toml
 ├── rust-toolchain.toml
 └── src
     ├── main.rs


### PR DESCRIPTION
#### Describe your changes.

in the "2. Create a new Nexus host project" section - the file was listed as `Cargo.tom`, which doesn’t exist.

it should be `Cargo.toml`, the correct config file for Rust projects.

fixed that to avoid confusion.