### PR TITLE
refactor: replace const LOG_SIZE with log_size() method in FrameworkEvalExt

### DIFF
--- a/prover/src/extensions/bit_op.rs
+++ b/prover/src/extensions/bit_op.rs
@@ -102,7 +102,9 @@ impl FrameworkEval for BitOpMultiplicityEval {
 }
 
 impl FrameworkEvalExt for BitOpMultiplicityEval {
-    const LOG_SIZE: u32 = BitOpMultiplicityEval::LOG_SIZE;
+    fn log_size() -> u32 {
+        Self::LOG_SIZE
+    }
 
     fn new(lookup_elements: &AllLookupElements) -> Self {
         let lookup_elements: &BitOpLookupElements = lookup_elements.as_ref();

--- a/prover/src/extensions/final_reg.rs
+++ b/prover/src/extensions/final_reg.rs
@@ -123,7 +123,9 @@ impl FrameworkEval for FinalRegEval {
 }
 
 impl FrameworkEvalExt for FinalRegEval {
-    const LOG_SIZE: u32 = Self::LOG_SIZE;
+    fn log_size() -> u32 {
+        Self::LOG_SIZE
+    }
 
     fn new(lookup_elements: &AllLookupElements) -> Self {
         let register_check_lookup_elements: &RegisterCheckLookupElements = lookup_elements.as_ref();

--- a/prover/src/extensions/multiplicity.rs
+++ b/prover/src/extensions/multiplicity.rs
@@ -108,7 +108,9 @@ impl<const LEN: usize, L: RegisteredLookupBound> FrameworkEval for MultiplicityE
 }
 
 impl<const LEN: usize, L: RegisteredLookupBound> FrameworkEvalExt for MultiplicityEval<LEN, L> {
-    const LOG_SIZE: u32 = Self::LOG_SIZE;
+    fn log_size() -> u32 {
+        Self::LOG_SIZE
+    }
 
     fn new(lookup_elements: &AllLookupElements) -> Self {
         let lookup: &L = lookup_elements.as_ref();

--- a/prover/src/extensions/multiplicity8.rs
+++ b/prover/src/extensions/multiplicity8.rs
@@ -95,7 +95,9 @@ impl FrameworkEval for MultiplicityEval8 {
 }
 
 impl FrameworkEvalExt for MultiplicityEval8 {
-    const LOG_SIZE: u32 = Self::LOG_SIZE;
+    fn log_size() -> u32 {
+        Self::LOG_SIZE
+    }
 
     fn new(lookup_elements: &AllLookupElements) -> Self {
         let lookup: &Range8LookupElements = lookup_elements.as_ref();


### PR DESCRIPTION
This PR addresses the TODO in prover/src/extensions/mod.rs by replacing the constant LOG_SIZE with a method log_size() in the FrameworkEvalExt trait. 

This change allows each component to define its own log size dynamically, improving flexibility and maintainability. 
