### PR TITLE
Optimize ROM Initialization: Use Iterators Instead of BTreeMap for Memory Byte Access

### DIFF
--- a/vm/src/emulator/executor.rs
+++ b/vm/src/emulator/executor.rs
@@ -153,6 +153,7 @@ use nexus_common::{
     cpu::{InstructionExecutor, Registers},
     memory::MemAccessSize,
 };
+use num_traits::FromPrimitive;
 use rangemap::RangeMap;
 use std::{
     cmp::max,
@@ -1161,12 +1162,9 @@ impl Emulator for LinearEmulator {
                 let base_address =
                     self.memory_layout.public_input_start() + i as u32 * WORD_SIZE as u32;
                 let word = word_content.to_le_bytes();
-                word.into_iter()
-                    .enumerate()
-                    .map(move |(j, byte)| MemoryInitializationEntry {
-                        address: base_address + j as u32,
-                        value: byte,
-                    })
+                word.into_iter().enumerate().map(move |(j, byte)| {
+                    MemoryInitializationEntry::new(base_address + j as u32, byte)
+                })
             });
 
         let public_io_loc_iter = self
@@ -1178,61 +1176,53 @@ impl Emulator for LinearEmulator {
             .flat_map(|(i, word_content)| {
                 let base_address = 0x80 + i as u32 * WORD_SIZE as u32;
                 let word = word_content.to_le_bytes();
-                word.into_iter()
-                    .enumerate()
-                    .map(move |(j, byte)| MemoryInitializationEntry {
-                        address: base_address + j as u32,
-                        value: byte,
-                    })
+                word.into_iter().enumerate().map(move |(j, byte)| {
+                    MemoryInitializationEntry::new(base_address + j as u32, byte)
+                })
             });
 
-        // Helper function to map (addr, byte) to MemoryInitializationEntry
-        fn map_to_mem_init_entry((addr, byte): (u32, u8)) -> MemoryInitializationEntry {
-            MemoryInitializationEntry {
-                address: addr,
-                value: byte,
-            }
-        }
         let mut rom_count = 0;
         let rom_iter = match self.static_rom_image_index {
             None => std::iter::empty().collect::<Vec<_>>().into_iter(),
-            Some((store, idx)) => {
-                if store == Modes::RW as usize {
+            Some((store, idx)) => match Modes::from_usize(store) {
+                Some(Modes::RW) => {
                     let mem_ro: FixedMemory<RO> = self.memory.frw_store[idx].clone().into();
                     mem_ro
                         .addr_val_bytes_iter()
                         .inspect(|_| rom_count += 1)
-                        .map(map_to_mem_init_entry)
+                        .map(|(address, value)| MemoryInitializationEntry::new(address, value))
                         .collect::<Vec<_>>()
                         .into_iter()
-                } else if store == Modes::RO as usize {
+                }
+                Some(Modes::RO) => {
                     let mem_ro: FixedMemory<RO> = self.memory.fro_store[idx].clone();
                     mem_ro
                         .addr_val_bytes_iter()
                         .inspect(|_| rom_count += 1)
-                        .map(map_to_mem_init_entry)
+                        .map(|(address, value)| MemoryInitializationEntry::new(address, value))
                         .collect::<Vec<_>>()
                         .into_iter()
-                } else if store == Modes::WO as usize {
+                }
+                Some(Modes::WO) => {
                     let mem_na: FixedMemory<NA> = self.memory.fwo_store[idx].clone().into();
                     mem_na
                         .addr_val_bytes_iter()
                         .inspect(|_| rom_count += 1)
-                        .map(map_to_mem_init_entry)
+                        .map(|(address, value)| MemoryInitializationEntry::new(address, value))
                         .collect::<Vec<_>>()
                         .into_iter()
-                } else if store == Modes::NA as usize {
+                }
+                Some(Modes::NA) => {
                     let mem_na: FixedMemory<NA> = self.memory.fna_store[idx].clone();
                     mem_na
                         .addr_val_bytes_iter()
                         .inspect(|_| rom_count += 1)
-                        .map(map_to_mem_init_entry)
+                        .map(|(address, value)| MemoryInitializationEntry::new(address, value))
                         .collect::<Vec<_>>()
                         .into_iter()
-                } else {
-                    std::iter::empty().collect::<Vec<_>>().into_iter()
                 }
-            }
+                _ => std::iter::empty().collect::<Vec<_>>().into_iter(),
+            },
         };
         let ram_initialization = &self.initial_static_ram_image;
         let ram_iter =
@@ -1240,9 +1230,11 @@ impl Emulator for LinearEmulator {
                 .as_byte_slice()
                 .iter()
                 .enumerate()
-                .map(|(offset, byte)| MemoryInitializationEntry {
-                    address: offset as u32 + self.initial_static_ram_image.base(),
-                    value: *byte,
+                .map(|(offset, byte)| {
+                    MemoryInitializationEntry::new(
+                        offset as u32 + self.initial_static_ram_image.base(),
+                        *byte,
+                    )
                 });
 
         let debug_logs: Vec<Vec<u8>> = if self.get_executor().logs.is_some() {

--- a/vm/src/emulator/executor.rs
+++ b/vm/src/emulator/executor.rs
@@ -158,6 +158,7 @@ use std::{
     cmp::max,
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
 };
+use itertools::Either;
 
 #[derive(Debug, Default)]
 pub struct Executor {
@@ -1186,10 +1187,8 @@ impl Emulator for LinearEmulator {
             });
         // TODO: avoid creating a BtreeMap and produce an iterator directly
         let rom_iter = match self.static_rom_image_index {
-            None => {
-                Box::new(std::iter::empty()) as Box<dyn Iterator<Item = MemoryInitializationEntry>>
-            }
-            Some(uidx) => Box::new(
+            None => Either::Left(std::iter::empty()),
+            Some(uidx) => Either::Right(
                 self.memory
                     .addr_val_bytes_iter(uidx)
                     .expect("invalid static_rom_image_index")
@@ -1197,7 +1196,7 @@ impl Emulator for LinearEmulator {
                         address: addr,
                         value: byte,
                     }),
-            ) as Box<dyn Iterator<Item = MemoryInitializationEntry>>,
+            ),
         };
         let ram_initialization = &self.initial_static_ram_image;
         let ram_iter =

--- a/vm/src/emulator/utils.rs
+++ b/vm/src/emulator/utils.rs
@@ -115,6 +115,14 @@ pub struct MemoryInitializationEntry {
     pub value: u8,
 }
 
+io!(MemoryInitializationEntry);
+
+impl MemoryInitializationEntry {
+    pub fn new(address: u32, value: u8) -> Self {
+        Self { address, value }
+    }
+}
+
 // One entry per byte because WO memory can be accessed bytewise
 #[derive(Debug, Copy, Clone)]
 pub struct PublicOutputEntry {
@@ -122,8 +130,13 @@ pub struct PublicOutputEntry {
     pub value: u8,
 }
 
-io!(MemoryInitializationEntry);
 io!(PublicOutputEntry);
+
+impl PublicOutputEntry {
+    pub fn new(address: u32, value: u8) -> Self {
+        Self { address, value }
+    }
+}
 
 // One entry per instruction because program memory is always accessed instruction-wise
 #[derive(Debug, Copy, Clone)]
@@ -278,7 +291,7 @@ impl View {
 }
 
 impl InternalView for View {
-    /// Return infomation about the program memory.
+    /// Return information about the program memory.
     fn get_program_memory(&self) -> &ProgramInfo {
         &self.program_memory
     }

--- a/vm/src/memory/fixed.rs
+++ b/vm/src/memory/fixed.rs
@@ -99,7 +99,7 @@ pub struct FixedMemoryAddrValBytesIter<'a, M: Mode> {
 impl<'a, M: Mode> Iterator for FixedMemoryAddrValBytesIter<'a, M> {
     type Item = (u32, u8);
     fn next(&mut self) -> Option<Self::Item> {
-        while let Some(addr) = self.range.next() {
+        for addr in self.range.by_ref() {
             // Use the instance method execute_read to get the byte value
             let val = self
                 .memory

--- a/vm/src/memory/fixed.rs
+++ b/vm/src/memory/fixed.rs
@@ -482,6 +482,62 @@ impl MemoryProcessor for FixedMemory<NA> {
     }
 }
 
+// Implement From for FixedMemory conversions according to the security lattice
+impl From<FixedMemory<RW>> for FixedMemory<RO> {
+    fn from(mem: FixedMemory<RW>) -> Self {
+        FixedMemory::<RO> {
+            base_address: mem.base_address,
+            max_len: mem.max_len,
+            vec: mem.vec,
+            __mode: std::marker::PhantomData,
+        }
+    }
+}
+
+impl From<FixedMemory<RW>> for FixedMemory<WO> {
+    fn from(mem: FixedMemory<RW>) -> Self {
+        FixedMemory::<WO> {
+            base_address: mem.base_address,
+            max_len: mem.max_len,
+            vec: mem.vec,
+            __mode: std::marker::PhantomData,
+        }
+    }
+}
+
+impl From<FixedMemory<RW>> for FixedMemory<NA> {
+    fn from(mem: FixedMemory<RW>) -> Self {
+        FixedMemory::<NA> {
+            base_address: mem.base_address,
+            max_len: mem.max_len,
+            vec: mem.vec,
+            __mode: std::marker::PhantomData,
+        }
+    }
+}
+
+impl From<FixedMemory<RO>> for FixedMemory<NA> {
+    fn from(mem: FixedMemory<RO>) -> Self {
+        FixedMemory::<NA> {
+            base_address: mem.base_address,
+            max_len: mem.max_len,
+            vec: mem.vec,
+            __mode: std::marker::PhantomData,
+        }
+    }
+}
+
+impl From<FixedMemory<WO>> for FixedMemory<NA> {
+    fn from(mem: FixedMemory<WO>) -> Self {
+        FixedMemory::<NA> {
+            base_address: mem.base_address,
+            max_len: mem.max_len,
+            vec: mem.vec,
+            __mode: std::marker::PhantomData,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use nexus_common::error::MemoryError;

--- a/vm/src/memory/fixed.rs
+++ b/vm/src/memory/fixed.rs
@@ -201,6 +201,20 @@ impl<M: Mode> FixedMemory<M> {
         }
         ret
     }
+
+    /// Iterator over addresses and values in the fixed memory, given bytewise, to avoid BTreeMap allocation
+    pub fn addr_val_bytes_iter(&self) -> impl Iterator<Item = (u32, u8)> + '_ {
+        (self.base_address..self.base_address + self.vec.len() as u32 * WORD_SIZE as u32)
+            .filter_map(move |addr| {
+                let val = self.execute_read(addr, MemAccessSize::Byte);
+                if let Ok(LoadOp::Op(_, _, value)) = val {
+                    debug_assert!(value <= 0xFF);
+                    Some((addr, value as u8))
+                } else {
+                    None
+                }
+            })
+    }
 }
 
 impl<M: Mode> FixedMemory<M> {

--- a/vm/src/memory/unified.rs
+++ b/vm/src/memory/unified.rs
@@ -355,39 +355,6 @@ impl UnifiedMemory {
             _ => Err(MemoryError::UndefinedMemoryRegion),
         }
     }
-
-    /// Returns a cloned FixedMemory<RO> for the given index in the RW store.
-    pub fn fixed_memory_as_ro(&self, idx: usize) -> Result<FixedMemory<RO>, MemoryError> {
-        if idx < self.frw_store.len() {
-            Ok(self.frw_store[idx].clone().into())
-        } else {
-            Err(MemoryError::UndefinedMemoryRegion)
-        }
-    }
-    /// Returns a cloned FixedMemory<RO> for the given index in the RO store.
-    pub fn fixed_memory_ro(&self, idx: usize) -> Result<FixedMemory<RO>, MemoryError> {
-        if idx < self.fro_store.len() {
-            Ok(self.fro_store[idx].clone())
-        } else {
-            Err(MemoryError::UndefinedMemoryRegion)
-        }
-    }
-    /// Returns a cloned FixedMemory<NA> for the given index in the WO store.
-    pub fn fixed_memory_as_na_from_wo(&self, idx: usize) -> Result<FixedMemory<NA>, MemoryError> {
-        if idx < self.fwo_store.len() {
-            Ok(self.fwo_store[idx].clone().into())
-        } else {
-            Err(MemoryError::UndefinedMemoryRegion)
-        }
-    }
-    /// Returns a cloned FixedMemory<NA> for the given index in the NA store.
-    pub fn fixed_memory_na(&self, idx: usize) -> Result<FixedMemory<NA>, MemoryError> {
-        if idx < self.fna_store.len() {
-            Ok(self.fna_store[idx].clone())
-        } else {
-            Err(MemoryError::UndefinedMemoryRegion)
-        }
-    }
 }
 
 impl MemoryProcessor for UnifiedMemory {
@@ -1090,7 +1057,7 @@ mod tests {
     fn test_no_variable_write() {
         let mut memory = UnifiedMemory::default();
 
-        // Write non-existant unified memory
+        // Write non-existent unified memory
         assert_eq!(
             memory.write(0x4000, MemAccessSize::Word, 0xABCD1234),
             Err(MemoryError::InvalidMemoryAccess(

--- a/vm/src/memory/unified.rs
+++ b/vm/src/memory/unified.rs
@@ -313,7 +313,9 @@ impl UnifiedMemory {
             }
             Some(Modes::RO) => {
                 if idx < self.fro_store.len() {
-                    Ok(AddrValBytesIter::RO(self.fro_store[idx].clone().into_addr_val_bytes_iter()))
+                    Ok(AddrValBytesIter::RO(
+                        self.fro_store[idx].clone().into_addr_val_bytes_iter(),
+                    ))
                 } else {
                     Err(MemoryError::UndefinedMemoryRegion)
                 }
@@ -328,7 +330,9 @@ impl UnifiedMemory {
             }
             Some(Modes::NA) => {
                 if idx < self.fna_store.len() {
-                    Ok(AddrValBytesIter::NA(self.fna_store[idx].clone().into_addr_val_bytes_iter()))
+                    Ok(AddrValBytesIter::NA(
+                        self.fna_store[idx].clone().into_addr_val_bytes_iter(),
+                    ))
                 } else {
                     Err(MemoryError::UndefinedMemoryRegion)
                 }

--- a/vm/src/memory/unified.rs
+++ b/vm/src/memory/unified.rs
@@ -274,6 +274,45 @@ impl UnifiedMemory {
         }
     }
 
+    /// Iterator over addresses and values in the fixed memory, given bytewise, to avoid BTreeMap allocation
+    pub fn addr_val_bytes_iter(
+        &self,
+        uidx: (usize, usize),
+    ) -> Result<Box<dyn Iterator<Item = (u32, u8)> + '_>, MemoryError> {
+        let (store, idx) = uidx;
+        match FromPrimitive::from_usize(store) {
+            Some(Modes::RW) => {
+                if idx < self.frw_store.len() {
+                    Ok(Box::new(self.frw_store[idx].addr_val_bytes_iter()))
+                } else {
+                    Err(MemoryError::UndefinedMemoryRegion)
+                }
+            }
+            Some(Modes::RO) => {
+                if idx < self.fro_store.len() {
+                    Ok(Box::new(self.fro_store[idx].addr_val_bytes_iter()))
+                } else {
+                    Err(MemoryError::UndefinedMemoryRegion)
+                }
+            }
+            Some(Modes::WO) => {
+                if idx < self.fwo_store.len() {
+                    Ok(Box::new(self.fwo_store[idx].addr_val_bytes_iter()))
+                } else {
+                    Err(MemoryError::UndefinedMemoryRegion)
+                }
+            }
+            Some(Modes::NA) => {
+                if idx < self.fna_store.len() {
+                    Ok(Box::new(self.fna_store[idx].addr_val_bytes_iter()))
+                } else {
+                    Err(MemoryError::UndefinedMemoryRegion)
+                }
+            }
+            _ => Err(MemoryError::UndefinedMemoryRegion),
+        }
+    }
+
     pub fn segment_words(
         &self,
         uidx: (usize, usize),

--- a/vm/src/memory/unified.rs
+++ b/vm/src/memory/unified.rs
@@ -76,6 +76,7 @@ use std::{
     collections::BTreeMap,
     fmt::{Debug, Display, Formatter, Result as FmtResult},
 };
+use itertools::Either;
 
 use super::{
     FixedMemory, LoadOp, MemAccessSize, MemoryProcessor, StoreOp, VariableMemory, NA, RO, RW, WO,
@@ -278,33 +279,33 @@ impl UnifiedMemory {
     pub fn addr_val_bytes_iter(
         &self,
         uidx: (usize, usize),
-    ) -> Result<Box<dyn Iterator<Item = (u32, u8)> + '_>, MemoryError> {
+    ) -> Result<Either<std::iter::Empty<(u32, u8)>, Box<dyn Iterator<Item = (u32, u8)> + '_>>, MemoryError> {
         let (store, idx) = uidx;
         match FromPrimitive::from_usize(store) {
             Some(Modes::RW) => {
                 if idx < self.frw_store.len() {
-                    Ok(Box::new(self.frw_store[idx].addr_val_bytes_iter()))
+                    Ok(Either::Right(Box::new(self.frw_store[idx].addr_val_bytes_iter())))
                 } else {
                     Err(MemoryError::UndefinedMemoryRegion)
                 }
             }
             Some(Modes::RO) => {
                 if idx < self.fro_store.len() {
-                    Ok(Box::new(self.fro_store[idx].addr_val_bytes_iter()))
+                    Ok(Either::Right(Box::new(self.fro_store[idx].addr_val_bytes_iter())))
                 } else {
                     Err(MemoryError::UndefinedMemoryRegion)
                 }
             }
             Some(Modes::WO) => {
                 if idx < self.fwo_store.len() {
-                    Ok(Box::new(self.fwo_store[idx].addr_val_bytes_iter()))
+                    Ok(Either::Right(Box::new(self.fwo_store[idx].addr_val_bytes_iter())))
                 } else {
                     Err(MemoryError::UndefinedMemoryRegion)
                 }
             }
             Some(Modes::NA) => {
                 if idx < self.fna_store.len() {
-                    Ok(Box::new(self.fna_store[idx].addr_val_bytes_iter()))
+                    Ok(Either::Right(Box::new(self.fna_store[idx].addr_val_bytes_iter())))
                 } else {
                     Err(MemoryError::UndefinedMemoryRegion)
                 }


### PR DESCRIPTION
#### Is this resolving a feature or a bug?

This PR resolves a feature request: it optimizes the way ROM initialization data is collected in the emulator by replacing unnecessary intermediate allocations with direct iterators.

#### If this PR is not minimal (it could be split into multiple PRs), please explain why the issues are best resolved together. 

The changes are tightly coupled and best resolved together because:
- The new iterator methods (addr_val_bytes_iter) in FixedMemory and UnifiedMemory are required to enable the refactor in LinearEmulator::finalize.

#### Describe your changes.

- Added an addr_val_bytes_iter method to FixedMemory and UnifiedMemory to provide efficient, allocation-free iteration over memory bytes as (address, byte) pairs.
- Refactored LinearEmulator::finalize to use the new iterator for ROM initialization, removing the need to allocate and populate a BTreeMap.

