### PR TITLE
Conditionally include pprof dependency only on Unix-like OSes

### DIFF
--- a/sdk/macros/profiler/Cargo.toml
+++ b/sdk/macros/profiler/Cargo.toml
@@ -10,4 +10,5 @@ categories.workspace = true
 publish.workspace = true
 
 [dependencies]
+[target.'cfg(unix)'.dependencies]
 pprof = { version = "0.13", features = ["prost-codec", "frame-pointer"] }


### PR DESCRIPTION
Before opening your pull request, please respond to the following prompts.

#### Is this resolving a feature or a bug?

Bug: fixes compilation on Windows

_NB: We DO NOT accept typo fixes. Generally, we do not accept edits to comments (starting with `//`) or minor grammatical and technical edits more generally, but do accept substantive fixes and improvements to the content of documentation comments (`///`) and README files._

#### Are there existing issue(s) that this PR would close?

#### If this PR is not minimal (it could be split into multiple PRs), please explain why the issues are best resolved together. 

#### Describe your changes.
The nexus-pofiler depends on [pprof-rs](https://github.com/tikv/pprof-rs), which supports macos and linux, but not windows due to its dependence on [nix](https://crates.io/crates/nix). At present, the nexus-profiler is [conditionally compiled](https://github.com/nexus-xyz/nexus-zkvm/blob/main/sdk/macros/profiler/src/lib.rs#L1-L2) only on macos and linux. However, pprof is always included as a Cargo dependency, and this seems to break the build for Windows.

This PR conditionally includes the pprof dependency only on unix-like OSes