### PR TITLE
fix Update utils.rs

### DIFF
--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -102,7 +102,7 @@ impl DurationTracker {
 
         self.min = std::cmp::min(self.min, *next);
         self.avg = (self.avg.mul_f64(prev) + *next).div_f64(curr);
-        self.max = std::cmp::max(self.min, *next);
+        self.max = std::cmp::max(self.max, *next);
     }
 }
 


### PR DESCRIPTION
fixes a logic error in the `DurationTracker` where the maximum observed duration was being compared against the **minimum** instead of the **previous maximum**. As a result, `self.max` was effectively reset on every update, rather than preserving the true maximum. This ensures that self.max always reflects the largest duration seen so far.
