### PR TITLE
Update `clap` dependency from 4.3 to 4.5.38

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ categories = ["cryptography"]
 publish = false
 
 [workspace.dependencies]
-clap = { version = "4.3", features = ["derive"] }
+clap = { version = "4.5.38", features = ["derive"] }
 num-traits = "0.2"
 num-derive = "0.4.2"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
### Description
Upgraded `clap` from version 4.3 to [4.5.38](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md#4538---2025-05-11) to include recent fixes and improvements, particularly in `derive` macros. This ensures better compatibility and leverages enhancements made in recent patch releases.