### PR TITLE
Fix: Correct typos in `vm/src/elf/error.rs`

### DIFF
--- a/vm/src/elf/error.rs
+++ b/vm/src/elf/error.rs
@@ -35,7 +35,7 @@ pub enum ParserError {
     #[error("Unaligned virtual address")]
     UnalignedVirtualAddress,
 
-    /// Segment size exceeeds maximum memory size
+    /// Segment size exceeds maximum memory size
     #[error("Segment size exceeds maximum memory size")]
     SegmentSizeExceedsMemorySize,
 
@@ -59,8 +59,8 @@ pub enum ParserError {
     #[error("address exceeds memory size")]
     AddressExceedsMemorySize,
 
-    /// No segment avaliable to load
-    #[error("no segment avaliable to load")]
+    /// No segment available to load
+    #[error("no segment available to load")]
     NoSegmentAvailable,
 
     /// No program header
@@ -115,7 +115,7 @@ pub enum ParserError {
     #[error(transparent)]
     Utf8Error(#[from] std::str::Utf8Error),
 
-    /// An issue occured interacting with the filesystem.
+    /// An issue occurred interacting with the filesystem.
     #[error(transparent)]
     IOError(#[from] std::io::Error),
 


### PR DESCRIPTION

### **Description:**

This pull request resolves minor typographical errors in comments and error messages within the `vm/src/elf/error.rs` file.

**Changes include:**
- `exceeeds` → `exceeds`
- `avaliable` → `available`
- `occured` → `occurred`
