### PR TITLE
Fix error in SDK README.md: "Cargo.tom" -> "Cargo.toml"

### DIFF
--- a/sdk/README.md
+++ b/sdk/README.md
@@ -41,7 +41,7 @@ This will create a new Rust project directory with the following structure:
 ```shell
 ./nexus-host
 ├── Cargo.lock
-├── Cargo.tom
+├── Cargo.toml
 ├── rust-toolchain.toml
 └── src
     ├── main.rs


### PR DESCRIPTION


_NB: We DO NOT accept typo fixes. Generally, we do not accept edits to comments (starting with `//`) or minor grammatical and technical edits more generally, but do accept substantive fixes and improvements to the content of documentation comments (`///`) and README files._

#### Describe your changes

This is not just a cosmetic typo — Cargo.tom is an invalid file name in Rust projects, and it may confuse users trying to follow the setup instructions. The correct file name is Cargo.toml, and fixing it improves the accuracy and usability of the README.