### PR TITLE
Enforce 16-byte alignment for stack_top in LinearMemoryLayout

### DIFF
--- a/vm/src/emulator/layout.rs
+++ b/vm/src/emulator/layout.rs
@@ -159,7 +159,7 @@ impl LinearMemoryLayout {
         self.public_output.assert_word_aligned();
         self.heap.assert_word_aligned();
         self.stack_bottom.assert_word_aligned();
-        self.stack_top.assert_word_aligned(); // TODO: this should actually be 0x10-aligned
+        self.stack_top.assert_aligned_to::<0x10>();
 
         Ok(())
     }


### PR DESCRIPTION
#### Is this resolving a feature or a bug?

This resolves a feature: it enforces the correct 16-byte alignment for the stack_top field in the memory layout, as required by the specification.

#### Are there existing issue(s) that this PR would close?

No, there are no existing issues related to this change.

#### If this PR is not minimal (it could be split into multiple PRs), please explain why the issues are best resolved together. 

This PR is minimal and focused solely on enforcing the correct alignment for stack_top.

#### Describe your changes.

This change updates the alignment check for the stack_top field in LinearMemoryLayout::validate from a 4-byte (word) alignment to a 16-byte alignment, as required by the memory layout specification. The check now uses the assert_aligned_to::<0x10>() method from the Alignable trait. This ensures that the stack top is always properly aligned for architectures or operations that require 16-byte boundaries. No other logic or functionality was modified.
