### PR TITLE
fix(fib_input_initial): correct method name value_a_effectitv…

### DIFF
--- a/prover/src/chips/cpu.rs
+++ b/prover/src/chips/cpu.rs
@@ -41,7 +41,7 @@ impl MachineChip for CpuChip {
     ) {
         // Fill ValueAEffectiveFlag to the main trace
         let value_a_effective_flag = match vm_step {
-            Some(vm_step) => vm_step.value_a_effectitve_flag(),
+            Some(vm_step) => vm_step.value_a_effective_flag(),
             None => false,
         };
         traces.fill_columns(row_idx, value_a_effective_flag, ValueAEffectiveFlag);

--- a/prover/src/trace/program.rs
+++ b/prover/src/trace/program.rs
@@ -92,7 +92,7 @@ impl ProgramStep {
     }
 
     /// Returns true if the valueA register is x0 register.
-    pub(crate) fn value_a_effectitve_flag(&self) -> bool {
+    pub(crate) fn value_a_effective_flag(&self) -> bool {
         self.get_op_a() != Register::X0
     }
 

--- a/prover2/machine/src/components/register_memory/trace.rs
+++ b/prover2/machine/src/components/register_memory/trace.rs
@@ -177,7 +177,7 @@ fn generate_trace_row(
         .get_result()
         .unwrap_or_else(|| program_step.get_value_a());
 
-    let reg3_value_effective_flag = program_step.value_a_effectitve_flag();
+    let reg3_value_effective_flag = program_step.value_a_effective_flag();
     let (reg3_value_effective_flag_aux, reg3_value_effective_flag_aux_inv): (BaseField, u8) = {
         if reg3_value_effective_flag {
             (BaseField::from(reg3_addr as u32).inverse(), reg3_addr)

--- a/prover2/trace/src/program.rs
+++ b/prover2/trace/src/program.rs
@@ -129,7 +129,7 @@ impl ProgramStep<'_> {
     }
 
     /// Returns true if the valueA register is x0 register.
-    pub fn value_a_effectitve_flag(&self) -> bool {
+    pub fn value_a_effective_flag(&self) -> bool {
         self.get_op_a() != Register::X0
     }
 


### PR DESCRIPTION

**Describe your changes.**
I corrected a typo in the method name from `value_a_effectitve_flag` to `value_a_effective_flag` to ensure proper method resolution.

