### PR TITLE
Use Rc to avoid clone() BasicBlock

### DIFF
--- a/vm/src/emulator/executor.rs
+++ b/vm/src/emulator/executor.rs
@@ -158,8 +158,8 @@ use rangemap::RangeMap;
 use std::{
     cmp::max,
     collections::{BTreeMap, HashMap, HashSet, VecDeque},
+    rc::Rc,
 };
-use std::rc::Rc;
 #[derive(Debug, Default)]
 pub struct Executor {
     // The CPU
@@ -634,7 +634,10 @@ impl Emulator for HarvardEmulator {
         }
 
         let entry = Rc::new(BasicBlockEntry::new(pc, block));
-        let _ = self.executor.basic_block_cache.insert(pc, entry.clone());
+        let _ = self
+            .executor
+            .basic_block_cache
+            .insert(pc, Rc::clone(&entry));
 
         self.executor
             .basic_block_ref_cache


### PR DESCRIPTION
#### Describe your changes.

I modified zkvm basic_block_cache to reduce the time consumption of data copying (**occupying 20% of bench_prover time**) through smart pointer sharing.

![Screenshot from 2025-07-03 16-20-27](https://github.com/user-attachments/assets/54e4e320-9e02-4422-9b98-07ab064982e7)
**Through performance analysis, it was found that a part of the time was wasted on data transfer**
![Screenshot from 2025-07-03 16-08-04](https://github.com/user-attachments/assets/6a1a23c6-414c-45a0-9989-77cbd1390c0b)