### PR TITLE
Use start.elapsed() instead of last_tick.elapsed() in Timer

### DIFF
--- a/cli/progress-bar/src/component/timer.rs
+++ b/cli/progress-bar/src/component/timer.rs
@@ -26,7 +26,7 @@ impl Component for Timer<'_> {
         if action.is_finished() {
             return Ok(Lines::new());
         }
-        let elapsed: FmtDuration = self.last_tick.elapsed().into();
+        let elapsed: FmtDuration = self.start.elapsed().into();
         let action = self.action.borrow();
 
         let heading_span = Span::new_styled(action.step_header.to_owned().bold().with(self.color))?;


### PR DESCRIPTION
Replaced the use of last_tick.elapsed() with start.elapsed() in the Timer component's draw_unchecked method.

This change ensures that the timer always displays the total elapsed time since the timer started, which matches typical user expectations for progress indicators.

Previously, last_tick was not updated anywhere except during initialization and finalize, so its use could be misleading and did not provide any additional value.

Using start.elapsed() makes the code simpler, more transparent, and consistent with how elapsed time is calculated elsewhere in the codebase.