### PR TITLE
cleanup: drop unused chrono import

### DIFF
--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -1,4 +1,3 @@
-use chrono;
 use libc::{getrusage, rusage, RUSAGE_CHILDREN, RUSAGE_SELF};
 use std::{fs::OpenOptions, io::Write, time::Duration};
 


### PR DESCRIPTION
#### Describe your changes.

Spotted a redundant import while digging through the benchmarks code - we're importing chrono with `use chrono;` but only using it with the qualified path `chrono::Local::now()`. 

