### PR TITLE
optimize vector allocation in execute_basic_block method

### DIFF
--- a/vm/src/emulator/executor.rs
+++ b/vm/src/emulator/executor.rs
@@ -289,12 +289,11 @@ pub trait Emulator {
         basic_block_entry: &BasicBlockEntry,
         force_provable_transcript: bool,
     ) -> Result<(Vec<InstructionResult>, MemoryTranscript)> {
-        let block_size = basic_block_entry.block.0.len() - (self.get_executor().cpu.pc.value as usize - basic_block_entry.start as usize) / WORD_SIZE;
-        let mut results: Vec<InstructionResult> = Vec::with_capacity(block_size);
-        let mut transcript: MemoryTranscript = Vec::with_capacity(block_size);
-
         let at = (self.get_executor().cpu.pc.value as usize - basic_block_entry.start as usize)
             / WORD_SIZE;
+        let block_size = basic_block_entry.block.0.len() - at;
+        let mut results: Vec<InstructionResult> = Vec::with_capacity(block_size);
+        let mut transcript: MemoryTranscript = Vec::with_capacity(block_size);
 
         // Execute the instructions in the basic block
         for instruction in basic_block_entry.block.0[at..].iter() {

--- a/vm/src/emulator/executor.rs
+++ b/vm/src/emulator/executor.rs
@@ -289,8 +289,9 @@ pub trait Emulator {
         basic_block_entry: &BasicBlockEntry,
         force_provable_transcript: bool,
     ) -> Result<(Vec<InstructionResult>, MemoryTranscript)> {
-        let mut results: Vec<InstructionResult> = Vec::new();
-        let mut transcript: MemoryTranscript = Vec::new();
+        let block_size = basic_block_entry.block.0.len() - (self.get_executor().cpu.pc.value as usize - basic_block_entry.start as usize) / WORD_SIZE;
+        let mut results: Vec<InstructionResult> = Vec::with_capacity(block_size);
+        let mut transcript: MemoryTranscript = Vec::with_capacity(block_size);
 
         let at = (self.get_executor().cpu.pc.value as usize - basic_block_entry.start as usize)
             / WORD_SIZE;


### PR DESCRIPTION
Improved performance by pre-allocating memory for result vectors in the execute_basic_block method. Instead of using Vec::new() which requires multiple reallocations as elements are added, this change uses Vec::with_capacity() with a precisely calculated size based on the number of instructions to be executed. This optimization reduces memory allocation overhead in a frequently called method of the emulator, improving overall performance especially for programs with many basic blocks