### PR TITLE
fix: replace Unix cp command with cross-platform file copy

### DIFF
--- a/runtime/macros/macro_expansion_tests/test.rs
+++ b/runtime/macros/macro_expansion_tests/test.rs
@@ -41,16 +41,13 @@ mod test {
         // Overwrite the main.rs file with the test file.
         let test_file = format!("macro_expansion_tests/tests/{test}.rs");
         let main_file = format!("{}/src/main.rs", tmp_project_path.clone().to_str().unwrap());
-        let mut output = Command::new("cp")
-            .arg(test_file)
-            .arg(main_file)
-            .output()
-            .expect("Failed to copy test file");
-
-        assert!(output.status.success());
+        let copy_result = std::fs::copy(&test_file, &main_file);
+        if let Err(e) = copy_result {
+            panic!("Failed to copy test file: {:?}", e);
+        }
 
         // Expand the procedural macro using native target.
-        output = Command::new("cargo")
+        let output = Command::new("cargo")
             .current_dir(tmp_project_path.clone())
             .arg("expand")
             .output()

--- a/runtime/macros/macro_expansion_tests/test.rs
+++ b/runtime/macros/macro_expansion_tests/test.rs
@@ -41,8 +41,7 @@ mod test {
         // Overwrite the main.rs file with the test file.
         let test_file = format!("macro_expansion_tests/tests/{test}.rs");
         let main_file = format!("{}/src/main.rs", tmp_project_path.clone().to_str().unwrap());
-        std::fs::copy(&test_file, &main_file)
-            .expect("Failed to copy test file");
+        std::fs::copy(&test_file, &main_file).expect("Failed to copy test file");
 
         // Expand the procedural macro using native target.
         let output = Command::new("cargo")

--- a/runtime/macros/macro_expansion_tests/test.rs
+++ b/runtime/macros/macro_expansion_tests/test.rs
@@ -41,10 +41,8 @@ mod test {
         // Overwrite the main.rs file with the test file.
         let test_file = format!("macro_expansion_tests/tests/{test}.rs");
         let main_file = format!("{}/src/main.rs", tmp_project_path.clone().to_str().unwrap());
-        let copy_result = std::fs::copy(&test_file, &main_file);
-        if let Err(e) = copy_result {
-            panic!("Failed to copy test file: {:?}", e);
-        }
+        std::fs::copy(&test_file, &main_file)
+            .expect("Failed to copy test file");
 
         // Expand the procedural macro using native target.
         let output = Command::new("cargo")


### PR DESCRIPTION
Replace Unix-specific 'cp' command with std::fs::copy() for cross-platform compatibility.

- Remove dependency on external Unix commands
- Use Rust standard library for file operations
- Enable macro expansion tests to run on Windows

Fixes: "program not found" error for cp command on Windows