### PR TITLE
refactor: fix clippy warnings in common-testing

### DIFF
--- a/common-testing/src/emulator.rs
+++ b/common-testing/src/emulator.rs
@@ -9,7 +9,7 @@ use nexus_vm::error::Result;
 use postcard::from_bytes_cobs;
 use serde::{de::DeserializeOwned, Serialize};
 
-use std::{path::PathBuf, process::Command};
+use std::{path::{Path, PathBuf}, process::Command};
 use tempfile::{tempdir, TempDir};
 
 #[derive(Clone)]
@@ -86,7 +86,7 @@ pub fn parse_output<T: DeserializeOwned>(
             .expect("Failed to parse exit code"),
     );
 
-    if output.len() == 0 {
+    if output.is_empty() {
         Ok((exit_code, None))
     } else {
         // Deserialize the rest as the output.
@@ -131,7 +131,7 @@ pub fn setup_guest_project(runtime_path: &PathBuf) -> TempDir {
 }
 
 /// Setup project.
-pub fn write_guest_source_code(tmp_project_path: &PathBuf, test_path: &str) {
+pub fn write_guest_source_code(tmp_project_path: &Path, test_path: &str) {
     // Overwrite the main.rs file with the test file.
     let main_file = format!("{}/src/main.rs", tmp_project_path.to_str().unwrap());
 
@@ -162,7 +162,7 @@ pub fn compile_guest_project(
         .arg(target)
         .env(
             "RUSTFLAGS",
-            &format!(
+            format!(
                 "{compile_flags} -C relocation-model=pic -C panic=abort -C link-arg=-T{}",
                 linker_script.display()
             ),
@@ -223,7 +223,7 @@ pub fn emulate(
 ) -> (Vec<usize>, Vec<u8>, Vec<u8>) {
     let mut exit_code_bytes: Vec<u8> = Vec::new();
     let mut output_bytes: Vec<u8> = Vec::new();
-    let ad = vec![0u8; 0xbeef as usize]; // placeholder ad until we have use for it
+    let ad = vec![0u8; 0xbeef_usize]; // placeholder ad until we have use for it
     let mut cycles = Vec::new();
 
     for elf in elfs {


### PR DESCRIPTION
Address clippy warnings

