### PR TITLE
fix: add Windows compatibility for benchmarks timing functions

### DIFF
--- a/benchmarks/src/runner.rs
+++ b/benchmarks/src/runner.rs
@@ -42,7 +42,7 @@ where
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let (start_time, initial_self, initial_children) = phase_start();
+    let timing_state = phase_start();
 
     // Simpler run process when no inputs are provided.
     let output = if public_input_bytes.is_empty() {
@@ -79,7 +79,7 @@ where
     assert!(output.status.success(), "Native execution failed");
 
     let (total_time, user_time, sys_time, _) =
-        phase_end(start_time, initial_self, initial_children);
+        phase_end(timing_state);
 
     (total_time, user_time, sys_time)
 }
@@ -122,10 +122,10 @@ pub fn run_benchmark<T>(
     // Measure native execution.
     let mut native_tracker = PhasesTracker::default();
     for _ in 0..iters {
-        let (start_time, initial_self, initial_children) = phase_start();
+        let timing_state = phase_start();
         let native_duration = measure_native_execution::<T>(&tmp_project_path, &public_input).0;
         let (_, native_user_time, native_sys_time, native_metrics) =
-            phase_end(start_time, initial_self, initial_children);
+            phase_end(timing_state);
 
         native_tracker.update(
             &native_duration,
@@ -147,11 +147,11 @@ pub fn run_benchmark<T>(
     for _ in 0..iters {
         let iter_elf = elf.clone();
 
-        let (start_time, initial_self, initial_children) = phase_start();
+        let timing_state = phase_start();
         (view, execution_trace) = k_trace(iter_elf, &[], &public_input, &private_input, K)
             .expect("error generating trace");
         let (emulation_duration, emulation_user_time, emulation_sys_time, emulation_metrics) =
-            phase_end(start_time, initial_self, initial_children);
+            phase_end(timing_state);
 
         emulation_tracker.update(
             &emulation_duration,
@@ -166,10 +166,10 @@ pub fn run_benchmark<T>(
 
     let mut proving_tracker = PhasesTracker::default();
     for _ in 0..iters {
-        let (start_time, initial_self, initial_children) = phase_start();
+        let timing_state = phase_start();
         proof = prove(&execution_trace, &view).unwrap();
         let (proving_duration, proving_user_time, proving_sys_time, proving_metrics) =
-            phase_end(start_time, initial_self, initial_children);
+            phase_end(timing_state);
 
         proving_tracker.update(
             &proving_duration,
@@ -184,14 +184,14 @@ pub fn run_benchmark<T>(
     for _ in 0..iters {
         let iter_proof = proof.clone();
 
-        let (start_time, initial_self, initial_children) = phase_start();
+        let timing_state = phase_start();
         verify(iter_proof, &view).unwrap();
         let (
             verification_duration,
             verification_user_time,
             verification_sys_time,
             verification_metrics,
-        ) = phase_end(start_time, initial_self, initial_children);
+        ) = phase_end(timing_state);
 
         verification_tracker.update(
             &verification_duration,

--- a/benchmarks/src/runner.rs
+++ b/benchmarks/src/runner.rs
@@ -78,8 +78,7 @@ where
 
     assert!(output.status.success(), "Native execution failed");
 
-    let (total_time, user_time, sys_time, _) =
-        phase_end(timing_state);
+    let (total_time, user_time, sys_time, _) = phase_end(timing_state);
 
     (total_time, user_time, sys_time)
 }
@@ -124,8 +123,7 @@ pub fn run_benchmark<T>(
     for _ in 0..iters {
         let timing_state = phase_start();
         let native_duration = measure_native_execution::<T>(&tmp_project_path, &public_input).0;
-        let (_, native_user_time, native_sys_time, native_metrics) =
-            phase_end(timing_state);
+        let (_, native_user_time, native_sys_time, native_metrics) = phase_end(timing_state);
 
         native_tracker.update(
             &native_duration,

--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -294,10 +294,10 @@ pub fn phase_end(timing_state: TimingState) -> (Duration, Duration, Duration, Ph
     let duration = start_time.elapsed();
     (
         duration,
-        duration, // User time approximation
+        duration,       // User time approximation
         Duration::ZERO, // System time
         PhaseMetrics {
-            peak_cpu: 0.0, // Not measurable on Windows easily
+            peak_cpu: 0.0,       // Not measurable on Windows easily
             peak_memory_gb: 0.0, // Not measurable on Windows easily
         },
     )

--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -1,7 +1,14 @@
+#[cfg(unix)]
 use libc::{getrusage, rusage, RUSAGE_CHILDREN, RUSAGE_SELF};
 use std::{fs::OpenOptions, io::Write, time::Duration};
 
 use crate::{models::BenchmarkResult, paths::results_file};
+
+/// Cross-platform timing state
+#[cfg(unix)]
+pub type TimingState = (std::time::Instant, rusage, rusage);
+#[cfg(windows)]
+pub type TimingState = std::time::Instant;
 
 /// Gets a timestamped version of a filename by appending timestamp and .csv extension.
 pub fn get_timestamped_filename(base_name: &str) -> String {
@@ -27,20 +34,37 @@ pub fn record_benchmark_results(result: &BenchmarkResult, filename: &str) {
 }
 
 /// Start timing and return resource usage.
+#[cfg(unix)]
 pub fn start_timer(usage_type: i32) -> rusage {
     let mut usage: rusage = unsafe { std::mem::zeroed() };
     unsafe { getrusage(usage_type, &mut usage) };
     usage
 }
 
+/// Start timing and return resource usage (Windows stub).
+#[cfg(windows)]
+pub fn start_timer(_usage_type: i32) -> std::time::Instant {
+    std::time::Instant::now()
+}
+
 /// Stop timing and return user and system time differences.
+#[cfg(unix)]
 pub fn stop_timer(start_usage: &rusage, usage_type: i32) -> (Duration, Duration) {
     let mut end_usage: rusage = unsafe { std::mem::zeroed() };
     unsafe { getrusage(usage_type, &mut end_usage) };
     calculate_time_diff(start_usage, &end_usage)
 }
 
+/// Stop timing and return user and system time differences (Windows stub).
+#[cfg(windows)]
+pub fn stop_timer(start_time: &std::time::Instant, _usage_type: i32) -> (Duration, Duration) {
+    let elapsed = start_time.elapsed();
+    // On Windows, we can't easily separate user and system time, so return elapsed time for both
+    (elapsed, Duration::ZERO)
+}
+
 /// Calculate user and system time differences between two rusage measurements.
+#[cfg(unix)]
 pub fn calculate_time_diff(start_usage: &rusage, end_usage: &rusage) -> (Duration, Duration) {
     let user_sec_diff = end_usage.ru_utime.tv_sec - start_usage.ru_utime.tv_sec;
     let user_usec_diff = end_usage.ru_utime.tv_usec - start_usage.ru_utime.tv_usec;
@@ -163,7 +187,8 @@ impl PhasesTracker {
 }
 
 /// Start measuring a phase and return initial state.
-pub fn phase_start() -> (std::time::Instant, rusage, rusage) {
+#[cfg(unix)]
+pub fn phase_start() -> TimingState {
     let mut initial_self_usage: rusage = unsafe { std::mem::zeroed() };
     let mut initial_children_usage: rusage = unsafe { std::mem::zeroed() };
     unsafe {
@@ -177,12 +202,16 @@ pub fn phase_start() -> (std::time::Instant, rusage, rusage) {
     )
 }
 
+/// Start measuring a phase and return initial state (Windows stub).
+#[cfg(windows)]
+pub fn phase_start() -> TimingState {
+    std::time::Instant::now()
+}
+
 /// End measuring a phase and return duration and metrics.
-pub fn phase_end(
-    start_time: std::time::Instant,
-    initial_self_usage: rusage,
-    initial_children_usage: rusage,
-) -> (Duration, Duration, Duration, PhaseMetrics) {
+#[cfg(unix)]
+pub fn phase_end(timing_state: TimingState) -> (Duration, Duration, Duration, PhaseMetrics) {
+    let (start_time, initial_self_usage, initial_children_usage) = timing_state;
     let mut final_self_usage: rusage = unsafe { std::mem::zeroed() };
     let mut final_children_usage: rusage = unsafe { std::mem::zeroed() };
     unsafe {
@@ -254,6 +283,22 @@ pub fn phase_end(
         PhaseMetrics {
             peak_cpu: cpu_percentage,
             peak_memory_gb,
+        },
+    )
+}
+
+/// End measuring a phase and return duration and metrics (Windows stub).
+#[cfg(windows)]
+pub fn phase_end(timing_state: TimingState) -> (Duration, Duration, Duration, PhaseMetrics) {
+    let start_time = timing_state;
+    let duration = start_time.elapsed();
+    (
+        duration,
+        duration, // User time approximation
+        Duration::ZERO, // System time
+        PhaseMetrics {
+            peak_cpu: 0.0, // Not measurable on Windows easily
+            peak_memory_gb: 0.0, // Not measurable on Windows easily
         },
     )
 }


### PR DESCRIPTION
Replaces POSIX-specific libc functions (getrusage, rusage) with cross-platform implementations using conditional compilation. 

- Add #[cfg(unix)]/#[cfg(windows)] guards for timing functions
- Create unified TimingState type for cross-platform compatibility  
- Maintain full backward compatibility with Unix systems
- Enable benchmarks compilation on Windows

Fixes: Windows compilation errors in benchmarks package