### PR TITLE
Add Address Overflow Check in `read_bytes` for Safe Memory Access

### DIFF
--- a/common/src/error/memory.rs
+++ b/common/src/error/memory.rs
@@ -22,10 +22,6 @@ pub enum MemoryError {
     #[error("Address calculation underflow")]
     AddressCalculationUnderflow,
 
-    // Address overflow during memory operation
-    #[error("Address overflow during memory operation")]
-    AddressOverflow,
-
     // Attempted to read a write-only memory address
     #[error(
         "Unauthorized read access: Attempted to read from write-only memory at address 0x{0:08X}"

--- a/common/src/error/memory.rs
+++ b/common/src/error/memory.rs
@@ -22,6 +22,10 @@ pub enum MemoryError {
     #[error("Address calculation underflow")]
     AddressCalculationUnderflow,
 
+    // Address overflow during memory operation
+    #[error("Address overflow during memory operation")]
+    AddressOverflow,
+
     // Attempted to read a write-only memory address
     #[error(
         "Unauthorized read access: Attempted to read from write-only memory at address 0x{0:08X}"

--- a/common/src/memory/traits.rs
+++ b/common/src/memory/traits.rs
@@ -247,7 +247,9 @@ pub trait MemoryProcessor: Default {
     fn read_bytes(&self, address: u32, size: usize) -> Result<Vec<u8>, MemoryError> {
         let mut data = vec![0; size];
         for (i, byte) in data.iter_mut().enumerate().take(size) {
-            match self.read(address + i as u32, MemAccessSize::Byte)? {
+            let addr = address.checked_add(i as u32)
+                .ok_or(MemoryError::AddressOverflow)?;
+            match self.read(addr, MemAccessSize::Byte)? {
                 LoadOp::Op(_, _, v) => *byte = v as u8,
             };
         }

--- a/common/src/memory/traits.rs
+++ b/common/src/memory/traits.rs
@@ -261,7 +261,9 @@ pub trait MemoryProcessor: Default {
     /// Only used for (unproven) ecalls, so does not return an operation record.
     fn write_bytes(&mut self, address: u32, data: &[u8]) -> Result<(), MemoryError> {
         for (i, &byte) in data.iter().enumerate() {
-            self.write(address + i as u32, MemAccessSize::Byte, byte as u32)?;
+            let addr = address.checked_add(i as u32)
+                .ok_or(MemoryError::AddressOverflow)?;
+            self.write(addr, MemAccessSize::Byte, byte as u32)?;
         }
         Ok(())
     }

--- a/common/src/memory/traits.rs
+++ b/common/src/memory/traits.rs
@@ -247,7 +247,8 @@ pub trait MemoryProcessor: Default {
     fn read_bytes(&self, address: u32, size: usize) -> Result<Vec<u8>, MemoryError> {
         let mut data = vec![0; size];
         for (i, byte) in data.iter_mut().enumerate().take(size) {
-            let addr = address.checked_add(i as u32)
+            let addr = address
+                .checked_add(i as u32)
                 .ok_or(MemoryError::AddressOverflow)?;
             match self.read(addr, MemAccessSize::Byte)? {
                 LoadOp::Op(_, _, v) => *byte = v as u8,
@@ -261,7 +262,8 @@ pub trait MemoryProcessor: Default {
     /// Only used for (unproven) ecalls, so does not return an operation record.
     fn write_bytes(&mut self, address: u32, data: &[u8]) -> Result<(), MemoryError> {
         for (i, &byte) in data.iter().enumerate() {
-            let addr = address.checked_add(i as u32)
+            let addr = address
+                .checked_add(i as u32)
                 .ok_or(MemoryError::AddressOverflow)?;
             self.write(addr, MemAccessSize::Byte, byte as u32)?;
         }

--- a/common/src/memory/traits.rs
+++ b/common/src/memory/traits.rs
@@ -249,7 +249,7 @@ pub trait MemoryProcessor: Default {
         for (i, byte) in data.iter_mut().enumerate().take(size) {
             let addr = address
                 .checked_add(i as u32)
-                .ok_or(MemoryError::AddressOverflow)?;
+                .ok_or(MemoryError::AddressCalculationOverflow)?;
             match self.read(addr, MemAccessSize::Byte)? {
                 LoadOp::Op(_, _, v) => *byte = v as u8,
             };
@@ -264,7 +264,7 @@ pub trait MemoryProcessor: Default {
         for (i, &byte) in data.iter().enumerate() {
             let addr = address
                 .checked_add(i as u32)
-                .ok_or(MemoryError::AddressOverflow)?;
+                .ok_or(MemoryError::AddressCalculationOverflow)?;
             self.write(addr, MemAccessSize::Byte, byte as u32)?;
         }
         Ok(())


### PR DESCRIPTION


**Description:**  
This pull request improves the safety of the `read_bytes` method in `MemoryProcessor` by adding an explicit check for address overflow using `checked_add`. If an overflow occurs, the method now returns a `MemoryError::AddressOverflow` error, preventing unintended memory access and potential bugs.  
