### PR TITLE
Fix Potential Panic in write_public_output Chunk Handling

### DIFF
--- a/runtime/src/io.rs
+++ b/runtime/src/io.rs
@@ -87,7 +87,12 @@ mod riscv32 {
 
         // Write bytes in word chunks to output memory.
         bytes.chunks(WORD_SIZE).enumerate().for_each(|(i, chunk)| {
-            let word = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+            let word = u32::from_le_bytes([
+                *chunk.get(0).unwrap_or(&0),
+                *chunk.get(1).unwrap_or(&0),
+                *chunk.get(2).unwrap_or(&0),
+                *chunk.get(3).unwrap_or(&0),
+            ]);
             write_output!((i + 1) * WORD_SIZE, word); // word 0 is reserved for the exit code
         });
 


### PR DESCRIPTION



**Description:**  
This PR improves the robustness of the `write_public_output` function by safely handling byte chunks when converting to `u32`.  
Now, each chunk is padded with zeros if its length is less than 4 bytes, preventing any possible out-of-bounds panics in edge cases.

