### PR TITLE
fix: correct S-type instruction encoding shift for immediate bits

### DIFF
--- a/common/src/riscv/encoder.rs
+++ b/common/src/riscv/encoder.rs
@@ -62,7 +62,7 @@ fn encode_s_type(instruction: &Instruction) -> u32 {
     let rs1 = (instruction.op_a as u32 & 0x1F) << 15;
     let rs2 = (instruction.op_b as u32 & 0x1F) << 20;
     let imm_4_0 = (instruction.op_c & 0x1F) << 7;
-    let imm_11_5 = (instruction.op_c & 0xFE0) << 20;
+    let imm_11_5 = (instruction.op_c & 0xFE0) << 25;
 
     imm_11_5 | rs2 | rs1 | funct3 | imm_4_0 | opcode
 }


### PR DESCRIPTION
Fix incorrect shift value in encode_s_type function for RISC-V S-type instructions.

The immediate value in S-type instructions (like SW, SH, SB) is split into two parts:
- imm[11:5] should be placed in bits [31:25] of the instruction
- imm[4:0] should be placed in bits [11:7] of the instruction

The previous implementation used a shift of 20 for imm_11_5, which placed the bits
in positions [26:20] instead of the correct [31:25]. This has been corrected to
use a shift of 25, ensuring proper RISC-V instruction encoding.

This fix ensures that S-type instructions are encoded according to the RISC-V
specification and will generate correct machine code.