### PR TITLE
Use into_owned() instead of to_string() on Cow<str>

### DIFF
--- a/sdk/src/stwo/seq.rs
+++ b/sdk/src/stwo/seq.rs
@@ -72,7 +72,7 @@ where
     fn compile(compiler: &mut impl Compile) -> Result<Self, <Self as Prover>::Error> {
         let elf_path = compiler.build()?;
 
-        Self::new_from_file(&elf_path.to_string_lossy().to_string())
+        Self::new_from_file(&elf_path.to_string_lossy().into_owned())
     }
 }
 


### PR DESCRIPTION


#### Describe your changes.
Replace to_string_lossy().to_string() with to_string_lossy().into_owned() in sdk/src/stwo/seq.rs.This avoids an unnecessary conversion on Cow<str>, is more idiomatic, and does not change behavior