### PR TITLE
Remove redundant Self: Sized bound from Prover::prove

### DIFF
--- a/sdk/src/traits.rs
+++ b/sdk/src/traits.rs
@@ -258,10 +258,7 @@ pub trait Prover: Sized {
     ) -> Result<Self::View, <Self as Prover>::Error>;
 
     /// Run the zkVM and return a verifiable proof, along with a view of the execution output.
-    fn prove(self) -> Result<(Self::View, Self::Proof), <Self as Prover>::Error>
-    where
-        Self: Sized,
-    {
+    fn prove(self) -> Result<(Self::View, Self::Proof), <Self as Prover>::Error> {
         Self::prove_with_input::<(), ()>(self, &(), &())
     }
 


### PR DESCRIPTION
Prover is already declared as trait Prover: Sized, so the extra where Self: Sized on prove is unnecessary.
No functional changes; simplifies the method signature.
Build verified with cargo check.