### PR TITLE
fix(stwo): pass PathBuf directly to new_from_file to avoid lossy path conversion

### DIFF
--- a/sdk/src/stwo/seq.rs
+++ b/sdk/src/stwo/seq.rs
@@ -72,7 +72,7 @@ where
     fn compile(compiler: &mut impl Compile) -> Result<Self, <Self as Prover>::Error> {
         let elf_path = compiler.build()?;
 
-        Self::new_from_file(&elf_path.to_string_lossy().into_owned())
+        Self::new_from_file(&elf_path)
     }
 }
 


### PR DESCRIPTION
Change: In sdk/src/stwo/seq.rs, use Self::new_from_file(&elf_path) instead of to_string_lossy().into_owned().
Reason: to_string_lossy() can mangle non‑UTF8 paths (notably on Windows), potentially breaking file loading. Passing PathBuf preserves the path as-is, matches Prover::new_from_file<P: AsRef<Path>>, aligns with legacy/* and examples, and avoids an unnecessary allocation.
Build: cargo check passes.