### PR TITLE
Preserve original function attributes in pprof macro

### DIFF
--- a/sdk/macros/src/pprof.rs
+++ b/sdk/macros/src/pprof.rs
@@ -5,36 +5,38 @@ use quote::quote;
 use syn::{parse_macro_input, Ident, ItemFn, LitStr};
 
 pub fn derive(attr: TokenStream, input: TokenStream) -> TokenStream {
-    let input_fn = parse_macro_input!(input as ItemFn);
-    let vis = input_fn.vis;
-    let sig = input_fn.sig;
-    let block = input_fn.block;
+	let input_fn = parse_macro_input!(input as ItemFn);
+	let vis = input_fn.vis;
+	let sig = input_fn.sig;
+	let block = input_fn.block;
+	let attrs = input_fn.attrs;
 
-    let file_name = if attr.is_empty() {
-        let function_name = format!("{}.pb", sig.ident);
-        LitStr::new(&function_name, Span::call_site())
-    } else {
-        parse_macro_input!(attr as LitStr)
-    };
+	let file_name = if attr.is_empty() {
+		let function_name = format!("{}.pb", sig.ident);
+		LitStr::new(&function_name, Span::call_site())
+	} else {
+		parse_macro_input!(attr as LitStr)
+	};
 
-    let found_crate = crate_name("nexus-profiler").expect("profiler is not in `Cargo.toml`");
+	let found_crate = crate_name("nexus-profiler").expect("profiler is not in `Cargo.toml`");
 
-    let profiler = match found_crate {
-        FoundCrate::Itself => quote!(crate::profiler),
-        FoundCrate::Name(name) => {
-            let ident = Ident::new(&name, Span::call_site());
-            quote!( #ident::profiler )
-        }
-    };
+	let profiler = match found_crate {
+		FoundCrate::Itself => quote!(crate::profiler),
+		FoundCrate::Name(name) => {
+			let ident = Ident::new(&name, Span::call_site());
+			quote!( #ident::profiler )
+		}
+	};
 
-    let output: proc_macro2::TokenStream = quote! {
-        #vis #sig {
-            let guard = #profiler::pprof_start();
-            let result = (|| #block)();
-            #profiler::pprof_end(guard, #file_name);
-            result
-        }
-    };
+	let output: proc_macro2::TokenStream = quote! {
+		#(#attrs)*
+		#vis #sig {
+			let guard = #profiler::pprof_start();
+			let result = (|| #block)();
+			#profiler::pprof_end(guard, #file_name);
+			result
+		}
+	};
 
-    output.into()
+	output.into()
 }

--- a/sdk/macros/src/pprof.rs
+++ b/sdk/macros/src/pprof.rs
@@ -5,38 +5,38 @@ use quote::quote;
 use syn::{parse_macro_input, Ident, ItemFn, LitStr};
 
 pub fn derive(attr: TokenStream, input: TokenStream) -> TokenStream {
-	let input_fn = parse_macro_input!(input as ItemFn);
-	let vis = input_fn.vis;
-	let sig = input_fn.sig;
-	let block = input_fn.block;
-	let attrs = input_fn.attrs;
+    let input_fn = parse_macro_input!(input as ItemFn);
+    let vis = input_fn.vis;
+    let sig = input_fn.sig;
+    let block = input_fn.block;
+    let attrs = input_fn.attrs;
 
-	let file_name = if attr.is_empty() {
-		let function_name = format!("{}.pb", sig.ident);
-		LitStr::new(&function_name, Span::call_site())
-	} else {
-		parse_macro_input!(attr as LitStr)
-	};
+    let file_name = if attr.is_empty() {
+        let function_name = format!("{}.pb", sig.ident);
+        LitStr::new(&function_name, Span::call_site())
+    } else {
+        parse_macro_input!(attr as LitStr)
+    };
 
-	let found_crate = crate_name("nexus-profiler").expect("profiler is not in `Cargo.toml`");
+    let found_crate = crate_name("nexus-profiler").expect("profiler is not in `Cargo.toml`");
 
-	let profiler = match found_crate {
-		FoundCrate::Itself => quote!(crate::profiler),
-		FoundCrate::Name(name) => {
-			let ident = Ident::new(&name, Span::call_site());
-			quote!( #ident::profiler )
-		}
-	};
+    let profiler = match found_crate {
+        FoundCrate::Itself => quote!(crate::profiler),
+        FoundCrate::Name(name) => {
+            let ident = Ident::new(&name, Span::call_site());
+            quote!( #ident::profiler )
+        }
+    };
 
-	let output: proc_macro2::TokenStream = quote! {
-		#(#attrs)*
-		#vis #sig {
-			let guard = #profiler::pprof_start();
-			let result = (|| #block)();
-			#profiler::pprof_end(guard, #file_name);
-			result
-		}
-	};
+    let output: proc_macro2::TokenStream = quote! {
+        #(#attrs)*
+        #vis #sig {
+            let guard = #profiler::pprof_start();
+            let result = (|| #block)();
+            #profiler::pprof_end(guard, #file_name);
+            result
+        }
+    };
 
-	output.into()
+    output.into()
 }


### PR DESCRIPTION
Reason: The macro did not re-emit input_fn.attrs, causing loss of function attributes and doc comments (e.g., #[inline], #[must_use], docs). This could affect inlining, linting, and generated documentation.
Change: Capture input_fn.attrs and expand them before the generated function signature (#(#attrs)* #vis #sig { ... }).
Goal: Preserve all original attributes and documentation while keeping profiling behavior unchanged.