### PR TITLE
fix(sdk/stwo): remove unnecessary to_owned() in COBS encoding

### DIFF
--- a/sdk/src/stwo/seq.rs
+++ b/sdk/src/stwo/seq.rs
@@ -104,9 +104,7 @@ impl Prover for Stwo<Local> {
     ) -> Result<Self::View, <Self as Prover>::Error> {
         let mut private_encoded = postcard::to_stdvec(&private_input).map_err(IOError::from)?;
         if !private_encoded.is_empty() {
-            let private = private_input.to_owned();
-
-            private_encoded = postcard::to_stdvec_cobs(&private).map_err(IOError::from)?;
+            private_encoded = postcard::to_stdvec_cobs(&private_input).map_err(IOError::from)?;
             let private_padded_len = (private_encoded.len() + 3) & !3;
 
             assert!(private_padded_len >= private_encoded.len());
@@ -115,9 +113,7 @@ impl Prover for Stwo<Local> {
 
         let mut public_encoded = postcard::to_stdvec(&public_input).map_err(IOError::from)?;
         if !public_encoded.is_empty() {
-            let public = public_input.to_owned();
-
-            public_encoded = postcard::to_stdvec_cobs(&public).map_err(IOError::from)?;
+            public_encoded = postcard::to_stdvec_cobs(&public_input).map_err(IOError::from)?;
             let public_padded_len = (public_encoded.len() + 3) & !3;
 
             assert!(public_padded_len >= public_encoded.len());
@@ -143,9 +139,7 @@ impl Prover for Stwo<Local> {
     ) -> Result<(Self::View, Self::Proof), <Self as Prover>::Error> {
         let mut private_encoded = postcard::to_stdvec(&private_input).map_err(IOError::from)?;
         if !private_encoded.is_empty() {
-            let private = private_input.to_owned();
-
-            private_encoded = postcard::to_stdvec_cobs(&private).map_err(IOError::from)?;
+            private_encoded = postcard::to_stdvec_cobs(&private_input).map_err(IOError::from)?;
             let private_padded_len = (private_encoded.len() + 3) & !3;
 
             assert!(private_padded_len >= private_encoded.len());
@@ -154,9 +148,7 @@ impl Prover for Stwo<Local> {
 
         let mut public_encoded = postcard::to_stdvec(&public_input).map_err(IOError::from)?;
         if !public_encoded.is_empty() {
-            let public = public_input.to_owned();
-
-            public_encoded = postcard::to_stdvec_cobs(&public).map_err(IOError::from)?;
+            public_encoded = postcard::to_stdvec_cobs(&public_input).map_err(IOError::from)?;
             let public_padded_len = (public_encoded.len() + 3) & !3;
 
             assert!(public_padded_len >= public_encoded.len());

--- a/sdk/src/traits.rs
+++ b/sdk/src/traits.rs
@@ -446,9 +446,7 @@ pub trait Verifiable: Serialize + DeserializeOwned {
         let mut input_encoded =
             postcard::to_stdvec(&expected_public_input).map_err(IOError::from)?;
         if !input_encoded.is_empty() {
-            let input = expected_public_input.to_owned();
-
-            input_encoded = postcard::to_stdvec_cobs(&input).map_err(IOError::from)?;
+            input_encoded = postcard::to_stdvec_cobs(&expected_public_input).map_err(IOError::from)?;
             let input_padded_len = (input_encoded.len() + 3) & !3;
 
             assert!(input_padded_len >= input_encoded.len());
@@ -458,9 +456,7 @@ pub trait Verifiable: Serialize + DeserializeOwned {
         let mut output_encoded =
             postcard::to_stdvec(&expected_public_output).map_err(IOError::from)?;
         if !output_encoded.is_empty() {
-            let output = expected_public_output.to_owned();
-
-            output_encoded = postcard::to_stdvec_cobs(&output).map_err(IOError::from)?;
+            output_encoded = postcard::to_stdvec_cobs(&expected_public_output).map_err(IOError::from)?;
             let output_padded_len = (output_encoded.len() + 3) & !3;
 
             assert!(output_padded_len >= output_encoded.len());

--- a/sdk/src/traits.rs
+++ b/sdk/src/traits.rs
@@ -446,7 +446,8 @@ pub trait Verifiable: Serialize + DeserializeOwned {
         let mut input_encoded =
             postcard::to_stdvec(&expected_public_input).map_err(IOError::from)?;
         if !input_encoded.is_empty() {
-            input_encoded = postcard::to_stdvec_cobs(&expected_public_input).map_err(IOError::from)?;
+            input_encoded =
+                postcard::to_stdvec_cobs(&expected_public_input).map_err(IOError::from)?;
             let input_padded_len = (input_encoded.len() + 3) & !3;
 
             assert!(input_padded_len >= input_encoded.len());
@@ -456,7 +457,8 @@ pub trait Verifiable: Serialize + DeserializeOwned {
         let mut output_encoded =
             postcard::to_stdvec(&expected_public_output).map_err(IOError::from)?;
         if !output_encoded.is_empty() {
-            output_encoded = postcard::to_stdvec_cobs(&expected_public_output).map_err(IOError::from)?;
+            output_encoded =
+                postcard::to_stdvec_cobs(&expected_public_output).map_err(IOError::from)?;
             let output_padded_len = (output_encoded.len() + 3) & !3;
 
             assert!(output_padded_len >= output_encoded.len());


### PR DESCRIPTION
Replaced to_owned() with direct reference encoding in COBS paths to avoid adding Clone/ToOwned bounds that are not present in Prover trait signatures and are unnecessary for postcard::to_stdvec_cobs.

Behavior preserved: two-step empty check (no COBS for empty payloads) and 4-byte padding remain unchanged; aligns with existing style where COBS encoding operates on references (see Viewable digest helpers).

Impact: eliminates a compilation hazard with generic S/T (no hidden Clone requirement) and avoids redundant allocations.

tests passed