### PR TITLE
docs: fix typos

### DIFF
--- a/prover/src/chips/instructions/i/blt.rs
+++ b/prover/src/chips/instructions/i/blt.rs
@@ -20,7 +20,7 @@ use super::add::{self};
 
 pub struct ExecutionResult {
     pub diff_bytes: Word,
-    pub borrow_bits: [bool; 2], // At 16-bit boudaries.
+    pub borrow_bits: [bool; 2], // At 16-bit boundaries.
     pub pc_next: Word,
     pub carry_bits: [bool; 2], // At 16-bit boundaries
     pub lt_flag: bool,

--- a/prover/src/chips/memory_check/register_mem_check.rs
+++ b/prover/src/chips/memory_check/register_mem_check.rs
@@ -126,7 +126,7 @@ impl MachineChip for RegisterMemCheckChip {
         let lookup_elements: &RegisterCheckLookupElements = lookup_elements.as_ref();
         let [value_a_effective_flag] = trace_eval!(trace_eval, ValueAEffectiveFlag);
 
-        // value_a_effective can be constrainted uniquely with value_a_effective_flag and value_a
+        // value_a_effective can be constrained uniquely with value_a_effective_flag and value_a
         let value_a = trace_eval!(trace_eval, ValueA);
         let value_a_effective = trace_eval!(trace_eval, ValueAEffective);
         for i in 0..WORD_SIZE {

--- a/vm/src/elf/error.rs
+++ b/vm/src/elf/error.rs
@@ -59,8 +59,8 @@ pub enum ParserError {
     #[error("address exceeds memory size")]
     AddressExceedsMemorySize,
 
-    /// No segment avaliable to load
-    #[error("no segment avaliable to load")]
+    /// No segment available to load
+    #[error("no segment available to load")]
     NoSegmentAvailable,
 
     /// No program header


### PR DESCRIPTION
### Description

This PR corrects several minor typos in comments and documentation across the codebase. The changes are non-functional and purely textual to improve clarity and maintain a clean, professional codebase.

### Details

- Corrected misspellings:
  - `boudaries` → `boundaries`
  - `constrainted` → `constrained`
  - `avaliable` → `available`

These fixes help enhance readability and eliminate minor distractions during development and code reviews.

### Additional Info

No logic or functionality has been modified. All changes are restricted to comments or non-executable doc annotations.