### PR TITLE
perf: optimize power-of-2 calculation using bit shift

### DIFF
--- a/prover-benches/benches/trace_gen.rs
+++ b/prover-benches/benches/trace_gen.rs
@@ -169,7 +169,7 @@ fn program_trace(log_size: u32) -> Vec<BasicBlock> {
         k = (k + 1) % NUM_REGISTERS;
         Some(inst)
     }))
-    .take(2usize.pow(log_size))
+    .take(1 << log_size)
     .collect();
     vec![BasicBlock::new(insts)]
 }


### PR DESCRIPTION
Replace 2usize.pow(log_size) with 1 << log_size in trace generation benchmark for better performance. Bit shift is significantly faster than the pow() function for power-of-2 calculations and maintains consistency with the identical code in stark_prove.rs benchmark.