### PR TITLE
Adjust ProgramMemCheck lookup tuple size to match actual tuple structure

### DIFF
--- a/prover/src/chips/memory_check/program_mem_check.rs
+++ b/prover/src/chips/memory_check/program_mem_check.rs
@@ -27,7 +27,7 @@ use crate::{
 /// ProgMemCheckChip needs to be located after CpuChip
 pub struct ProgramMemCheckChip;
 
-const LOOKUP_TUPLE_SIZE: usize = 3 * WORD_SIZE;
+const LOOKUP_TUPLE_SIZE: usize = 2 * WORD_SIZE_HALVED + WORD_SIZE;
 stwo_constraint_framework::relation!(ProgramCheckLookupElements, LOOKUP_TUPLE_SIZE);
 
 impl MachineChip for ProgramMemCheckChip {


### PR DESCRIPTION
Update LOOKUP_TUPLE_SIZE in ProgramMemCheckChip from 3 * WORD_SIZE to 2 * WORD_SIZE_HALVED + WORD_SIZE, aligning the declared relation size with the actual tuples used (Pc halfwords, instruction halfwords, counter bytes). No other logic changes; existing asserts already matched the new size.