### PR TITLE
fix: Remove unused core::str import in vm/build.rs

### DIFF
--- a/vm/build.rs
+++ b/vm/build.rs
@@ -1,4 +1,3 @@
-use core::str;
 use std::process::Command;
 
 use tempfile::tempdir;


### PR DESCRIPTION
#### Describe your changes.
Remove unused import of core::str that generates compiler warning. The build script does not use any functionality from core::str module.
