### PR TITLE
fix: docs fill N columns with value convertible into base fields

### DIFF
--- a/prover2/trace/src/builder.rs
+++ b/prover2/trace/src/builder.rs
@@ -47,7 +47,7 @@ impl<C: AirColumn> TraceBuilder<C> {
     }
 
     /// Returns a copy of `N` raw columns in range `[offset..offset + N]` at `row`, where
-    /// `N` is assumed to be equal `Column::size` of a `col`.
+    /// `N` must equal `col.size()`.
     pub fn column<const N: usize>(&self, row: usize, col: C) -> [BaseField; N] {
         assert_eq!(col.size(), N, "column size mismatch");
 
@@ -57,7 +57,7 @@ impl<C: AirColumn> TraceBuilder<C> {
     }
 
     /// Returns mutable reference to `N` raw columns in range `[offset..offset + N]` at `row`,
-    /// where `N` is assumed to be equal `Column::size` of a `col`.
+    /// where `N` must equal `col.size()`.
     pub fn column_mut<const N: usize>(&mut self, row: usize, col: C) -> [&mut BaseField; N] {
         assert_eq!(col.size(), N, "column size mismatch");
 
@@ -68,7 +68,7 @@ impl<C: AirColumn> TraceBuilder<C> {
         })
     }
 
-    /// Fills four columns with u32 value.
+    /// Fills N columns with a value convertible into base fields.
     pub fn fill_columns<const N: usize, T: IntoBaseFields<N>>(
         &mut self,
         row: usize,


### PR DESCRIPTION
Replace misleading “Fills four columns with u32 value” wording with accurate, generic phrasing in prover2/trace/src/builder.rs, prover/src/trace/trace_builder.rs, and prover/src/trace/program_trace.rs. This aligns docs with the actual API fill_columns<const N, T: IntoBaseFields<N>>, which fills N columns for any value convertible into base fields, not necessarily u32 or 4 columns. Also clarify that N must equal col.size().