### PR TITLE
Enforce JALR target alignment by clearing LSB in PC::jalr

### DIFF
--- a/common/src/cpu/pc.rs
+++ b/common/src/cpu/pc.rs
@@ -21,7 +21,8 @@ impl PC {
 
     // Jump and Link Register: Set PC to rs1 + imm
     pub fn jalr(&mut self, rs1: u32, imm: u32) {
-        self.value = rs1.wrapping_add(sign_extension_jalr(imm));
+        // RISC-V spec: JALR clears bit 0 of the target address (enforce 2-byte alignment)
+        self.value = rs1.wrapping_add(sign_extension_jalr(imm)) & !1u32;
     }
 }
 

--- a/vm/src/cpu/instructions/i/jal.rs
+++ b/vm/src/cpu/instructions/i/jal.rs
@@ -198,4 +198,24 @@ mod tests {
         assert_eq!(res, Some(0x1004));
         assert_eq!(cpu.registers.read(Register::X4), 0x1004);
     }
+
+    #[test]
+    fn test_jalr_alignment_masks_lsb() {
+        let mut cpu = Cpu::default();
+        cpu.pc.value = 0x1000;
+
+        // Set base address in rs1 to an odd value
+        cpu.registers.write(Register::X1, 0x2001);
+
+        // Use offset that keeps sum odd: 0x0 (so 0x2001 + 0x0)
+        let offset = 0x0;
+        let bare_instruction = Instruction::new_ir(Opcode::from(BuiltinOpcode::JALR), 5, 1, offset);
+        let instruction = JalrInstruction::decode(&bare_instruction, &cpu.registers);
+
+        // Execute the jalr instruction
+        let _ = instruction.write_back(&mut cpu);
+
+        // PC must have LSB cleared to enforce 2-byte alignment
+        assert_eq!(cpu.pc.value, 0x2000);
+    }
 }


### PR DESCRIPTION
Align JALR target to 2-byte boundary per RISC-V spec by masking off bit 0 in PC::jalr. Emulator previously computed the target without clearing the LSB, while the prover already enforced pc_next = pc_next_aux & 0xFFFFFFFE. This mismatch could lead to divergent behavior and potential instruction-address misalignment. The change brings emulator semantics in line with the specification and the prover constraints, and adds a unit test to lock in the behavior.