### PR TITLE
Rename _next_is_first to _is_last_row in Keccak constraints

### DIFF
--- a/prover/src/extensions/keccak/round/constraints.rs
+++ b/prover/src/extensions/keccak/round/constraints.rs
@@ -84,7 +84,7 @@ impl<E: EvalAtRow> KeccakRoundEval<'_, E> {
             // is_padding is the last column in the component trace.
             let [is_padding, _next_is_padding] =
                 self.eval.next_interaction_mask(ORIGINAL_TRACE_IDX, [0, 1]);
-            let _next_is_first = self.eval.get_preprocessed_column(PreProcessedColumnId {
+            let _is_last_row = self.eval.get_preprocessed_column(PreProcessedColumnId {
                 id: format!("keccak_{index}_is_last_row", index = self.index),
             });
             // constraint padding column to be either 0 or 1, and enforce that it only goes from 1 to 0 on last row.
@@ -93,7 +93,7 @@ impl<E: EvalAtRow> KeccakRoundEval<'_, E> {
             // TODO: enforcing this constraint requires bit reversing the trace
             //
             // self.eval.add_constraint(
-            //     (E::F::one() - next_is_first.clone())
+            //     (E::F::one() - _is_last_row.clone())
             //         * is_padding.clone()
             //         * (E::F::one() - next_is_padding.clone()),
             // );


### PR DESCRIPTION
Renamed misleading variable _next_is_first to _is_last_row in:
- prover/src/extensions/keccak/memory_check/constraints.rs
- prover/src/extensions/keccak/round/constraints.rs

Updated TODO comments to reference _is_last_row accordingly.

No logic changes; only naming and comment fixes. Lint passes.

Why this is necessary:
- The referenced preprocessed column IDs (keccak_memory_check_is_last_row, keccak_{index}_is_last_row) semantically indicate “is last row,” not “is first.”
- The old name was a copy/paste artifact used in multiple components and could mislead future contributors and obstruct correct enforcement of the padding transition invariant mentioned in the TODO.
- Aligns naming with actual data semantics across components, improving readability and reducing risk of incorrect future changes.