### PR TITLE
Remove unnecessary unreachable_patterns allow in register_relation macro

### DIFF
--- a/prover2/machine/src/lookups/macros.rs
+++ b/prover2/machine/src/lookups/macros.rs
@@ -56,7 +56,6 @@ macro_rules! register_relation {
                     self
                 }
 
-                #[allow(unreachable_patterns)]
                 fn unwrap_ref(it: &$_enum) -> &Self {
                     match it {
                         $_enum::$name(inner) => inner,


### PR DESCRIPTION
The enum generated by register_relation! in this codebase always contains multiple variants, making the _ match arm reachable. The #[allow(unreachable_patterns)] on unwrap_ref was unnecessary and could mask legitimate issues. Removed the attribute to keep linting meaningful; builds against nightly-2025-04-06 and mirrors the analogous implementation in prover/src/components/lookups.rs which does not use this allow.