### PR TITLE
Runtime: replace unreachable_unchecked after SYS_EXIT with safe spin loop

### DIFF
--- a/runtime/src/runtime.rs
+++ b/runtime/src/runtime.rs
@@ -29,9 +29,11 @@ fn panic(info: &PanicInfo) -> ! {
     let _ = write_output!(0, EXIT_PANIC);
     // Finish with exit syscall.
     let _ = ecall!(SYS_EXIT, EXIT_PANIC);
-    // Ecall will trigger exit syscall, so we will never return.
-    unsafe {
-        core::hint::unreachable_unchecked();
+    // Ecall is expected to terminate the program, but in case it doesn't
+    // (e.g., due to a VM/environment malfunction), avoid UB from
+    // unreachable_unchecked by spinning indefinitely instead.
+    loop {
+        core::hint::spin_loop();
     }
 }
 


### PR DESCRIPTION


### Description
- Replaces unsafe `core::hint::unreachable_unchecked()` in the panic handler with a safe infinite spin loop after `SYS_EXIT`.
- Adds a brief comment explaining the rationale.

Why:
- `SYS_EXIT` is expected to terminate, but if it doesn’t (e.g., VM/environment malfunction), hitting `unreachable_unchecked` is UB.
- Spinning avoids UB while preserving the “never return” contract.

Impact:
- Safer runtime behavior in edge cases; no functional changes for normal execution.
- No API changes; no performance impact in the non-failure path.


