### PR TITLE
Fix mixed-base range in Alignable tests (use 0x1001..0x1005)

### DIFF
--- a/common/src/memory/alignment.rs
+++ b/common/src/memory/alignment.rs
@@ -119,7 +119,7 @@ mod tests {
     fn test_alignable() {
         // Test `word_align`
         #[allow(clippy::reversed_empty_ranges)] // absurd false positive
-        for i in 0x1001..1005 {
+        for i in 0x1001..0x1005 {
             assert_eq!((i as u32).word_align(), 0x1004);
             assert_eq!((i as usize).word_align(), 0x1004);
         }


### PR DESCRIPTION
The test used a mixed-base range 0x1001..1005, which is empty (4097..1005), so the loop never ran and didn’t validate word_align. I changed the upper bound to hex 0x1005, making the range 0x1001..0x1005 so the loop executes and correctly checks alignment for 0x1001–0x1004.