### PR TITLE
fix(testing): record Linear emulator cycles after execution

### DIFF
--- a/common-testing/src/emulator.rs
+++ b/common-testing/src/emulator.rs
@@ -304,8 +304,8 @@ pub fn emulate(
                     &public_input_bytes,
                     &private_input_bytes,
                 );
-                cycles.push(emulator.executor.global_clock);
                 let _ = emulator.execute(false);
+                cycles.push(emulator.executor.global_clock);
 
                 let view = emulator.finalize();
                 exit_code_bytes = view


### PR DESCRIPTION
Previously, in common-testing/src/emulator.rs, the Linear emulator branch pushed emulator.executor.global_clock into the cycles vector before calling execute(false). Since the global clock starts at 0 and increments during instruction execution, this resulted in reporting 0 cycles regardless of the program, and it was inconsistent with Harvard and TwoPass branches, which read the clock after execution.
This change moves the cycles.push(emulator.executor.global_clock) to immediately after execute(false) in the Linear branch, aligning behavior with Harvard/TwoPass and ensuring cycles reflect actual executed instructions. No functional behavior changes beyond correcting the reported cycle count; tests didn’t fail previously because cycles were not asserted anywhere.