### PR TITLE
Fix ELF loader: correct BSS handling and safe bounds checks

### DIFF
--- a/vm/src/elf/parser.rs
+++ b/vm/src/elf/parser.rs
@@ -272,7 +272,9 @@ fn parse_segment_content(
             // Partial tail: copy present bytes and pad with zeros
             let start = absolute_address as usize;
             let end = file_end as usize;
-            let slice = data.get(start..end).ok_or(ParserError::InvalidOffsetInFile)?;
+            let slice = data
+                .get(start..end)
+                .ok_or(ParserError::InvalidOffsetInFile)?;
             let mut buf = [0u8; WORD_SIZE];
             let copy_len = core::cmp::min(slice.len(), WORD_SIZE);
             buf[..copy_len].copy_from_slice(&slice[..copy_len]);


### PR DESCRIPTION


### Description
- Ensure segments read only file-backed bytes (`p_filesz`) and zero-fill the remainder up to `p_memsz` (BSS).
- Add safe bounds checks and handle partial trailing words with zero-padding.
- Keep existing section-based classification logic intact.

#### Why
Previously, the parser read up to `p_memsz` from the file, which could:
- Read past the end of the ELF buffer,
- Fill BSS with garbage instead of zeros.

#### Changes
- `parse_segment_info` now returns `(vaddr, offset, file_size, mem_size)`.
- `parse_segment_content` reads only `[offset, offset + file_size)`, zero-filling the rest.
- Replace out-of-bounds reads with explicit `InvalidOffsetInFile`.

