### PR TITLE
Remove unused AirColumn import from erased.rs

### DIFF
--- a/prover2/machine/src/framework/traits/erased.rs
+++ b/prover2/machine/src/framework/traits/erased.rs
@@ -17,7 +17,6 @@ use stwo::{
 };
 use stwo_constraint_framework::{FrameworkEval, InfoEvaluator, TraceLocationAllocator};
 
-use nexus_vm_prover_air_column::AirColumn;
 use nexus_vm_prover_trace::component::ComponentTrace;
 
 use super::builtin::BuiltInComponent;


### PR DESCRIPTION
Deleted use nexus_vm_prover_air_column::AirColumn; from prover2/machine/src/framework/traits/erased.rs.
The trait is not referenced in this file