### PR TITLE
Progress bar: fix fill calculation to avoid premature 100% display

### DIFF
--- a/cli/progress-bar/src/component/loading.rs
+++ b/cli/progress-bar/src/component/loading.rs
@@ -33,7 +33,12 @@ impl Component for LoadingBar<'_> {
             )?;
 
             let percentage = iteration as f64 / total as f64;
-            let amount = (percentage * WIDTH as f64).ceil() as usize;
+            // Use floor to avoid prematurely showing a full bar before completion.
+            // Clamp to WIDTH - 1 while not finished to keep visual consistency.
+            let mut amount = (percentage * WIDTH as f64).floor() as usize;
+            if !action.is_finished() {
+                amount = amount.min(WIDTH.saturating_sub(1));
+            }
 
             let loading_bar = format!(
                 " [{test:=>bar_amt$}{empty:padding_amt$}] {}/{}: ...",


### PR DESCRIPTION

### Summary
Correct the progress bar fill logic to prevent showing a full bar before the final step completes.

### Changes
- Use floor instead of ceil for fill calculation.
- Clamp fill to `WIDTH - 1` while not finished.

### Why
Avoids misleading UX where the bar appears complete one step too early.

