### PR TITLE
Remove dead output_log in TwoPass emulate branch

### DIFF
--- a/common-testing/src/emulator.rs
+++ b/common-testing/src/emulator.rs
@@ -271,15 +271,6 @@ pub fn emulate(
                         .iter()
                         .map(|public_output_entry| public_output_entry.value)
                         .collect();
-                    let _output_log = if let Some(lines) = view.view_debug_logs() {
-                        lines
-                            .iter()
-                            .map(|line| String::from_utf8_lossy(line).to_string())
-                            .collect::<Vec<String>>()
-                            .join("\n")
-                    } else {
-                        "".into()
-                    };
                 }
                 cycles.push(cur_cycles);
             }


### PR DESCRIPTION
The _output_log aggregation was dead code: logging is never enabled (execute(false) with no capture_logs(true)), view_debug_logs() always returned Some(vec![]), and the resulting string was discarded. Removing it eliminates redundant work and clarifies intent.