### PR TITLE
fix(macros): silence unused imm param in InstructionEmitter impl

### DIFF
--- a/precompiles/macros/src/generation.rs
+++ b/precompiles/macros/src/generation.rs
@@ -28,7 +28,7 @@ pub(crate) fn generate_instruction_impls(paths: &[PrecompilePath]) -> TokenStrea
             quote! {
                 impl InstructionEmitter for #path {
                     #[inline(always)]
-                    fn emit_instruction(rs1: u32, rs2: u32, imm: u32) -> u32 {
+                    fn emit_instruction(rs1: u32, rs2: u32, _imm: u32) -> u32 {
                         #[cfg(target_arch = "riscv32")] {
                             let mut rd: u32;
                             unsafe {


### PR DESCRIPTION
Rename the unused parameter imm to _imm in the generated impl InstructionEmitter within precompiles/macros/src/generation.rs. The R-type precompile instruction has no immediate by design; the parameter is kept for interface consistency with potential I-/S-type encodings where imm is meaningful.