### PR TITLE
Improve error handling for repeated 'size' attributes in derive_impl.rs

### DIFF
--- a/prover2/air-column/air-column-derive/src/derive_impl.rs
+++ b/prover2/air-column/air-column-derive/src/derive_impl.rs
@@ -225,7 +225,8 @@ fn collect_variants(input: &syn::ItemEnum) -> syn::Result<Vec<ParsedVariant>> {
                 if size.is_none() {
                     size = Some(value)
                 } else {
-                    return Err(syn::Error::new_spanned(attr, "repeating `size` attribute"));
+                    return Err(syn::Error::new_spanned(attr, "Multiple 'size' attributes found. Only one 'size' attribute is permitted per variant. Check the variant definition."));
+
                 }
             } else {
                 return Err(syn::Error::new_spanned(attr, "integer value expected"));


### PR DESCRIPTION
This PR enhances the error handling in `derive_impl.rs` by improving the error message when multiple `size` attributes are found on a variant.

#### Is this resolving a feature or a bug?
This improves developer experience by making error messages clearer.

#### Are there existing issue(s) that this PR would close?
No existing issue; this is an enhancement based on code review.

#### Describe your changes
Updated the duplicate `size` attribute error message from "repeating size attribute" to "Multiple 'size' attributes found. Only one 'size' attribute is permitted per variant. Check the variant definition." to provide clearer guidance to developers.