### PR TITLE
Use WORD_SIZE for final_reg masks in evaluator

### DIFF
--- a/prover/src/extensions/final_reg.rs
+++ b/prover/src/extensions/final_reg.rs
@@ -82,8 +82,8 @@ impl FrameworkEval for FinalRegEval {
         // let _reg_idx = eval.next_trace_mask();
         let reg_idx = RegisterIdx::new(FinalRegEval::LOG_SIZE);
         let reg_idx = eval.get_preprocessed_column(reg_idx.id());
-        let final_timestamp: Vec<_> = (0..4).map(|_| eval.next_trace_mask()).collect();
-        let final_value: Vec<_> = (0..4).map(|_| eval.next_trace_mask()).collect();
+        let final_timestamp: Vec<_> = (0..WORD_SIZE).map(|_| eval.next_trace_mask()).collect();
+        let final_value: Vec<_> = (0..WORD_SIZE).map(|_| eval.next_trace_mask()).collect();
 
         // Add initial register memory state
         let mut tuple: [E::F; Self::TUPLE_SIZE] = std::array::from_fn(|_| E::F::zero());


### PR DESCRIPTION
Replace hardcoded (0..4) loops with (0..WORD_SIZE) when reading final_timestamp and final_value masks in FinalRegEval::evaluate. This aligns the evaluator with the rest of the component, which is parameterized by WORD_SIZE for tuple sizes and trace generation. The change removes a hidden assumption that WORD_SIZE is 4 and prevents dimension mismatches if WORD_SIZE changes in the future.