### PR TITLE
Remove duplicated timestamp assert in LoadStore chip

### DIFF
--- a/prover/src/chips/instructions/i/load_store.rs
+++ b/prover/src/chips/instructions/i/load_store.rs
@@ -124,11 +124,6 @@ impl MachineChip for LoadStoreChip {
         traces.fill_columns(row_idx, carry_bits, Column::CarryFlag);
         let clk = row_idx as u32 + 1;
         for memory_record in vm_step.step.memory_records.iter() {
-            assert_eq!(
-                memory_record.get_timestamp(),
-                (row_idx as u32 + 1),
-                "timestamp mismatch"
-            );
             assert_eq!(memory_record.get_timestamp(), clk, "timestamp mismatch");
             let byte_address = memory_record.get_address();
             assert_eq!(


### PR DESCRIPTION
The timestamp was asserted twice against equivalent expressions: first to (row_idx + 1) and then to clk, where clk is defined as (row_idx + 1). This made the second assert a strict duplicate of the first, providing no additional safety or coverage. Kept the single assert against clk for clarity