### PR TITLE
Fix misleading doc comment for parse_segments return type

### DIFF
--- a/vm/src/elf/parser.rs
+++ b/vm/src/elf/parser.rs
@@ -464,14 +464,14 @@ fn debug_segment_info(segment: &ProgramHeader, section_map: &HashMap<&str, (u64,
 ///
 /// # Returns
 ///
-/// A tuple containing:
-/// * A vector of u32 values representing the encoded instructions.
-/// * A BTreeMap representing the memory image, where keys are addresses and values are word contents.
-/// * The base address (u32) of the executable segment.
+/// A `Result<ParsedElfData>` containing:
+/// * Encoded instructions as `u32` words.
+/// * Read-only and writable memory images.
+/// * The base address (`u32`) of the executable segment.
 ///
 /// # Errors
 ///
-/// Returns a `ParserError` if any parsing or validation errors occur.
+/// Returns a `ParserError` variant if any parsing or validation errors occur.
 pub fn parse_segments(elf: &ElfBytes<LittleEndian>, data: &[u8]) -> Result<ParsedElfData> {
     let mut instructions = Instructions::new();
     let mut writable_memory = RawMemoryImage::new();


### PR DESCRIPTION


### Description

#### Is this resolving a feature or a bug?
Documentation bug: align the `parse_segments` doc comment with its actual return type and contents.

#### Are there existing issue(s) that this PR would close?
None that I’m aware of.

#### If this PR is not minimal (it could be split into multiple PRs), please explain why the issues are best resolved together.
This PR is minimal.

#### Describe your changes.
- Updated the Rust documentation comment for `parse_segments` in `vm/src/elf/parser.rs` to correctly describe the return type as `Result<ParsedElfData>` and summarize its fields (encoded instructions, read-only/writable memory images, base address).
- Clarified the Errors section to reference `ParserError` variants.

