### PR TITLE
docs: correct BasicBlock encoding references and module responsibilities

### DIFF
--- a/common/src/riscv/encoder.rs
+++ b/common/src/riscv/encoder.rs
@@ -1,19 +1,16 @@
-//! # Basic Block and Instruction Encoder for RISC-V
+//! # Instruction Encoder for RISC-V
 //!
 //! This module provides functionality for encoding RISC-V instructions into their little-endian binary representations.
 //! It supports encoding various instruction types, including R-type, I-type, S-type, B-type, U-type, and J-type.
 //!
 //! ## Encoding an Instruction
 //!
-//! The `Instruction` struct implement an `encode` method that returns the binary representation
+//! The `Instruction` struct implements an `encode` method that returns the binary representation
 //! of the instruction as a `u32`. It supports encoding of built-in RISC-V instructions
 //! based on their instruction type.
 //!
-//! ## Encoding a BasicBlock
-//!
-//! The `BasicBlock` struct implements an `encode` method that returns a `Vec<u32>` containing
-//! the binary representations of the instructions in the block. It supports encoding
-//! of built-in RISC-V instructions based on their instruction type.
+//! Note: Encoding of `BasicBlock` (a sequence of instructions) is defined in the VM crate at
+//! `vm/src/riscv/instructions/basic_block.rs` via `BasicBlock::encode`, which leverages `Instruction::encode`.
 
 use crate::{
     constants::KECCAKF_OPCODE,

--- a/vm/README.md
+++ b/vm/README.md
@@ -137,9 +137,9 @@ The project is organized into several key modules:
      - Provides `decode_instruction`, `decode_instructions`, and `decode_until_end_of_a_block` functions
      - Supports decoding of custom dynamic instructions (R-type, S-type, and I-type)
      - Implements efficient instruction parsing using bit manipulation
-   - `instructions/`: Defines RISC-V instruction structures and utilities
-     - `basic_block.rs`: Represents a sequence of instructions (basic block)
-       - Provides methods for encoding, decoding, and displaying basic blocks
+  - `instructions/`: Defines RISC-V instruction structures and utilities
+  - `basic_block.rs`: Represents a sequence of instructions (basic block)
+    - Provides methods for encoding and displaying basic blocks
      - `instruction.rs`: Defines the unified `Instruction` struct for all instruction types
        - Implements `InstructionDecoder` for processing various RISC-V instruction formats
        - Supports RV32IM instruction set


### PR DESCRIPTION
- common/src/riscv/encoder.rs: Removed misleading “BasicBlock” encoding section, fixed header, and clarified that block encoding lives in vm/src/riscv/instructions/basic_block.rs; minor grammar/wording cleanup.
- vm/README.md: Updated basic_block.rs description to “encoding and displaying” (removed incorrect “decoding” claim).
- Why: The docs incorrectly implied BasicBlock encoding was implemented in common, and that basic_block.rs handled decoding. This misstates module boundaries, confuses contributors, and can lead to incorrect usage. Clarifying ownership improves discoverability, reduces onboarding friction, and prevents misuse.