### PR TITLE
Upgrade GitHub Action to download-artifact@v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
           targets: riscv32im-unknown-none-elf
 
       - name: Download pre-built host project
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: nexus-host-project
           path: /tmp/nexus-host


### PR DESCRIPTION
Version v5 brings performance improvements, enhanced artifact handling, and better workflow compatibility.
Release notes:https://github.com/actions/download-artifact/releases/tag/v5.0.0

Change:
uses: actions/download-artifact@v4 -> uses: actions/download-artifact@v5