### PR TITLE
fix(elf): prevent panic in get_instructions with bounds checking

### DIFF
--- a/vm/src/elf/loader.rs
+++ b/vm/src/elf/loader.rs
@@ -92,8 +92,9 @@ impl ElfFile {
         }
     }
 
-    pub fn get_instructions(&self, address: usize, n: usize) -> &[u32] {
-        &self.instructions[address..address + n]
+    pub fn get_instructions(&self, address: usize, n: usize) -> Option<&[u32]> {
+        let end = address.checked_add(n)?;
+        self.instructions.get(address..end)
     }
 
     pub fn from_bytes(data: &[u8]) -> Result<Self, VMError> {


### PR DESCRIPTION


## **Description:**

#### Is this resolving a feature or a bug?
**Bug fix** - This resolves a potential runtime panic in the ELF loader when accessing instruction slices with invalid bounds.

#### Are there existing issue(s) that this PR would close?
No existing issues - this is a proactive safety improvement.

#### If this PR is not minimal (it could be split into multiple PRs), please explain why the issues are best resolved together.
This is a minimal, single-purpose fix that only affects one function.

#### Describe your changes.

**Problem:**
The `get_instructions` method in `vm/src/elf/loader.rs` could panic when accessing instruction slices with invalid `address` or `n` parameters due to unchecked array bounds access.

**Solution:**
- Changed return type from `&[u32]` to `Option<&[u32]>`
- Added bounds checking using `checked_add()` and `slice.get()`

