### PR TITLE
Fix public output sentinel in CheckedView::new_from_expected

### DIFF
--- a/sdk/src/traits.rs
+++ b/sdk/src/traits.rs
@@ -69,7 +69,7 @@ impl CheckedView for nexus_core::nvm::View {
             memory_layout.public_input_address_location(),
             &[
                 memory_layout.public_input_start().to_le_bytes(),
-                memory_layout.exit_code().to_le_bytes(), // the exit code is the first word of the output
+                memory_layout.public_output_start().to_le_bytes(), // the exit code is the first word of the output
             ]
             .concat(),
         )


### PR DESCRIPTION
The second sentinel word at PUBLIC_OUTPUT_ADDRESS_LOCATION (0x84) must point to the base of the public output segment. The runtime’s write_output! macro loads this address and writes relative to it, while the layout invariants define public_output_start() = exit_code() + WORD_SIZE. Previously we mistakenly stored exit_code() there, which would shift public output writes into the exit code word and misalign the rest of the output. This change writes public_output_start() instead, aligning View construction with the runtime macros and the memory layout specification.