### PR TITLE
refactor(prover/cpu): remove duplicate is_padding declaration in add_constraints

### DIFF
--- a/prover/src/chips/cpu.rs
+++ b/prover/src/chips/cpu.rs
@@ -370,7 +370,6 @@ impl MachineChip for CpuChip {
         let [is_sll] = trace_eval!(trace_eval, IsSll);
         let [is_srl] = trace_eval!(trace_eval, IsSrl);
         let [is_sra] = trace_eval!(trace_eval, IsSra);
-        let [is_padding] = trace_eval!(trace_eval, IsPadding);
         let [is_sb] = trace_eval!(trace_eval, IsSb);
         let [is_sh] = trace_eval!(trace_eval, IsSh);
         let [is_sw] = trace_eval!(trace_eval, IsSw);


### PR DESCRIPTION
Removed the second is_padding binding in CpuChip.add_constraints() to avoid variable shadowing and improve readability.
Reused the earlier is_padding value throughout the function; no logic or behavior changes.
first binding - 324 line