### PR TITLE
prover: build keccak state array in-place without Vec allocation

### DIFF
--- a/prover/src/chips/custom.rs
+++ b/prover/src/chips/custom.rs
@@ -92,15 +92,13 @@ impl KeccakChip {
             let idx = (address - addr) / WORD_SIZE as u32;
             input[idx as usize] = value;
         }
-        let input: Vec<u64> = input
-            .chunks(2)
-            .map(|c| {
-                let low = c[0] as u64;
-                let high = c[1] as u64;
-                low + (high << 32)
-            })
-            .collect();
-        input.try_into().expect("invalid input state size")
+        let mut state = [0u64; 25];
+        for (i, c) in input.chunks_exact(2).enumerate() {
+            let low = c[0] as u64;
+            let high = c[1] as u64;
+            state[i] = low + (high << 32);
+        }
+        state
     }
 
     /// Modifies side-note timestamps for accessed memory and returns previous values.


### PR DESCRIPTION
- Remove the intermediate Vec<u64> in KeccakChip::keccak_input_from_mem_records() and construct the [u64; 25] state directly from [u32; 50].
- This change avoids a per-call heap allocation and a redundant try_into() size check. No APIs in the codebase require a Vec here, and downstream functions operate on [u64; 25], so behavior is unchanged.