### PR TITLE
Update download-artifact action to version 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,7 +221,7 @@ jobs:
           targets: riscv32im-unknown-none-elf
 
       - name: Download pre-built host project
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v6
         with:
           name: nexus-host-project
           path: /tmp/nexus-host


### PR DESCRIPTION
Updated the download-artifact action from v5 to v6. This version adds support for Node.js v24.x and updates the underlying dependencies.
Release notes: https://github.com/actions/download-artifact/releases/tag/v6.0.0
