### PR TITLE
fix: remove redundant unsafe block in sys_alloc_aligned

### DIFF
--- a/runtime/src/alloc.rs
+++ b/runtime/src/alloc.rs
@@ -56,12 +56,10 @@ pub unsafe extern "C" fn sys_alloc_aligned(bytes: usize, align: usize) -> *mut u
 
     // Get the current stack pointer
     let stack_ptr: usize;
-    unsafe {
-        core::arch::asm!(
-            "mv {}, sp",
-            out(reg) stack_ptr
-        );
-    }
+    core::arch::asm!(
+        "mv {}, sp",
+        out(reg) stack_ptr
+    );
 
     // Check if the heap is about to clash with the stack
     if heap_pos > stack_ptr {


### PR DESCRIPTION
#### Is this resolving a feature or a bug?

This is a code quality improvement / bug fix. 

#### Are there existing issue(s) that this PR would close?

No existing issues.

#### If this PR is not minimal (it could be split into multiple PRs), please explain why the issues are best resolved together. 

This PR is minimal. It contains a single, focused change: removing one redundant `unsafe` block from `sys_alloc_aligned` function.

#### Describe your changes.

Removed the redundant `unsafe` block wrapping the `core::arch::asm!` call on lines 59-64 of `runtime/src/alloc.rs`. 
Since `sys_alloc_aligned` is already marked as `unsafe extern "C"`, the nested `unsafe` block added no value and only cluttered the code. 
The inline assembly code itself remains unchanged.