### PR TITLE
Remove redundant PathBuf clone in compiler linker setup Summar

### DIFF
--- a/sdk/src/compile/mod.rs
+++ b/sdk/src/compile/mod.rs
@@ -64,7 +64,7 @@ pub trait Compile {
             fs::create_dir_all(parent)?;
         }
 
-        let mut file = fs::File::create(linker_path.clone())?;
+        let mut file = fs::File::create(linker_path.as_path())?;
         file.write_all(linker_script.as_bytes())?;
 
         Ok(linker_path)


### PR DESCRIPTION
Replace the unnecessary linker_path.clone() with linker_path.as_path() when creating the linker file avoid the extra allocation while keeping behavior unchanged