### PR TITLE
refactor(tests): replace unnecessary Vec allocations

### DIFF
--- a/tests/testing-framework/src/lib.rs
+++ b/tests/testing-framework/src/lib.rs
@@ -682,8 +682,8 @@ mod test {
     #[test]
     #[serial]
     fn test_fib() {
-        let inputs = vec![1u32, 10u32, 20u32];
-        let outputs = vec![1u32, 34u32, 4181u32];
+        let inputs = [1u32, 10u32, 20u32];
+        let outputs = [1u32, 34u32, 4181u32];
         let emulators = vec![
             EmulatorType::Harvard,
             EmulatorType::default_linear(),


### PR DESCRIPTION
Replace heap-allocated Vec with stack-allocated arrays for constant test data in test_fib function. These values are known at compile time and never modified, making Vec unnecessary and less efficient.

