### PR TITLE
vm: replace stdout printing in BasicBlock with writer-based API

### DIFF
--- a/vm/src/riscv/instructions/basic_block.rs
+++ b/vm/src/riscv/instructions/basic_block.rs
@@ -25,12 +25,14 @@ impl BasicBlock {
         self.0.is_empty()
     }
 
-    pub fn print_with_offset(&self, offset: usize) {
-        println!("┌─────────────────────────────────────────────────");
+    pub fn write_with_offset<W: std::io::Write>(&self, w: &mut W, offset: usize) -> std::io::Result<()> {
+        use std::io::Write as _;
+        writeln!(w, "┌─────────────────────────────────────────────────")?;
         for (j, instruction) in self.0.iter().enumerate() {
-            println!("│ {:3x}: {}", j * 4 + offset, instruction);
+            writeln!(w, "│ {:3x}: {}", j * 4 + offset, instruction)?;
         }
-        println!("└─────────────────────────────────────────────────");
+        writeln!(w, "└─────────────────────────────────────────────────")?;
+        Ok(())
     }
 
     pub fn len(&self) -> usize {


### PR DESCRIPTION


### Description
- Summary: Replace direct stdout prints in `BasicBlock` with a writer-based method to make output controllable and testable.
- What changed: Removed `print_with_offset`; added `write_with_offset<W: std::io::Write>(&mut W, offset) -> std::io::Result<()>` in `vm/src/riscv/instructions/basic_block.rs`. Kept `Display` unchanged.
- Why: Avoid hardcoded stdout in library code; align with existing `Display`; improve testability and CI signal.
- Migration:
  - Old: `basic_block.print_with_offset(offset)`
  - New: `let _ = basic_block.write_with_offset(&mut std::io::stdout(), offset);`

