### PR TITLE
ci: bump upload-artifact to v5 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,14 +189,14 @@ jobs:
           popd
 
       - name: Upload cargo-nexus binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: cargo-nexus
           path: target/release/cargo-nexus
           retention-days: 90
 
       - name: Upload pre-built host project
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: nexus-host-project
           path: /tmp/nexus-host


### PR DESCRIPTION
upgrade both upload-artifact steps in .github/workflows/ci.yml from v4 to v5
proof:https://github.com/actions/upload-artifact/releases/tag/v5.0.0
