### PR TITLE
Remove unnecessary clone in TypeR bitwise finalized c_val parts

### DIFF
--- a/prover2/machine/src/components/execution/bitwise/type_r.rs
+++ b/prover2/machine/src/components/execution/bitwise/type_r.rs
@@ -72,6 +72,6 @@ impl<T: TypeRBitwiseDecoding> BitwiseOp for TypeR<T> {
         let c_val_high =
             std::array::from_fn(|i| (&component_trace.original_trace[len - WORD_SIZE + i]).into());
 
-        [c_val_low.clone(), c_val_high]
+        [c_val_low, c_val_high]
     }
 }


### PR DESCRIPTION
FinalizedColumn from LowBits::combine_from_column() has 'static lifetime and can be moved directly when assembling the [c_val_low, c_val_high] pair in combine_finalized_c_val_parts() (prover2/machine/src/components/execution/bitwise/type_r.rs).
Removing .clone() avoids superfluous Rc refcount increments for virtual columns and aligns with the pattern used in 
type_i.rs, where only repeated elements are cloned, not entire arrays.