### PR TITLE
fix: remove duplicate clone in HashSet insert

### DIFF
--- a/runtime/macros/src/io.rs
+++ b/runtime/macros/src/io.rs
@@ -198,9 +198,10 @@ pub(crate) fn handle_input(
                 return stream_error(id, "Expected an identifier.");
             }
             let name = id.path.segments.get(0).unwrap().ident.clone();
-            if !public_inputs.insert(name.clone()) {
+            if public_inputs.contains(&name) {
                 return stream_error(&attr_args, format!("Duplicate public input: {:?}.", name));
             }
+            public_inputs.insert(name);
         } else {
             return stream_error(x, "Expected an identifier.");
         }


### PR DESCRIPTION
Replace HashSet::insert() with contains() check followed by insert() to avoid cloning the Ident twice. The previous code cloned name when creating the variable and again when calling insert(), which was unnecessary since we can check for duplicates first.


