### PR TITLE
chore(vm): remove unused InternalView import from trace.rs

### DIFF
--- a/vm/src/trace.rs
+++ b/vm/src/trace.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     cpu::{instructions::InstructionResult, RegisterFile},
     elf::ElfFile,
-    emulator::{Emulator, HarvardEmulator, InternalView, LinearEmulator, LinearMemoryLayout, View},
+    emulator::{Emulator, HarvardEmulator, LinearEmulator, LinearMemoryLayout, View},
     error::{Result, VMError, VMErrorKind},
     memory::MemoryRecords,
     riscv::{BasicBlock, Instruction},


### PR DESCRIPTION
Removes unused `InternalView` import from `vm/src/trace.rs`.