### PR TITLE
fix: incorrect custom_input example in compile_error!

### DIFF
--- a/runtime/macros/src/io.rs
+++ b/runtime/macros/src/io.rs
@@ -265,7 +265,7 @@ pub(crate) fn handle_input(
     let target_check = if !matches!(input_type, InputType::Custom) {
         quote! {
             #[cfg(not(target_arch = "riscv32"))]
-            compile_error!("NexusVM public and private input interfaces are not available for native builds, use a custom handler instead. Ex: #[nexus_rt::custom_input(bar)]");
+            compile_error!("NexusVM public and private input interfaces are not available for native builds, use a custom handler instead. Ex: #[nexus_rt::custom_input((x,y,z), fizz)]");
         }
     } else {
         quote! {}


### PR DESCRIPTION
The compile_error! message in runtime/macros/src/io.rs incorrectly suggested #[nexus_rt::custom_input(bar)], implying a single-arg attribute, but the custom_input parser requires two arguments: the input identifier or tuple and the handler function identifier. This change updates the example to #[nexus_rt::custom_input((x,y,z), fizz)], aligning the error message with the actual attribute grammar and with existing examples and macro expansion tests in the repository, preventing users from following an invalid example.