### PR TITLE
refactor: remove redundant .take(size)

### DIFF
--- a/common/src/memory/traits.rs
+++ b/common/src/memory/traits.rs
@@ -246,7 +246,7 @@ pub trait MemoryProcessor: Default {
     /// Only used for (unproven) ecalls, so does not return an operation record.
     fn read_bytes(&self, address: u32, size: usize) -> Result<Vec<u8>, MemoryError> {
         let mut data = vec![0; size];
-        for (i, byte) in data.iter_mut().enumerate().take(size) {
+        for (i, byte) in data.iter_mut().enumerate() {
             let addr = address
                 .checked_add(i as u32)
                 .ok_or(MemoryError::AddressCalculationOverflow)?;


### PR DESCRIPTION
The .take(size) call on `data.iter_mut().enumerate()` in `MemoryProcessor::read_bytes()` was redundant because data is preallocated to exactly size, so the iterator already yields size elements. Removing it keeps the loop semantics identical while reducing an unnecessary iterator adapter, aligning this function with `write_bytes()` which already avoids `.take`.