### PR TITLE
refactor: optimize Vec allocation in io_entries_into_vec

### DIFF
--- a/vm/src/emulator/utils.rs
+++ b/vm/src/emulator/utils.rs
@@ -63,8 +63,7 @@ pub fn convert_instruction(registry: &registry::InstructionExecutorRegistry, ins
 }
 
 pub fn io_entries_into_vec<T: IOEntry>(base: u32, entries: &[T]) -> Vec<u8> {
-    let mut vec: Vec<u8> = Vec::new();
-    vec.resize(entries.len(), u8::default());
+    let mut vec = vec![0u8; entries.len()];
 
     entries.iter().for_each(|entry: &T| {
         let loc = (entry.address() - base) as usize;


### PR DESCRIPTION
Replace Vec::new() + resize() with vec![] macro in io_entries_into_vec function. The original code was doing two operations: Vec::new() creates empty vec with capacity 0, then resize() allocates memory and fills with default values. Changed to vec![0u8; entries.len()] which does single allocation upfront, more idiomatic Rust, and slightly better performance since it avoids potential realloc. 