### PR TITLE
chore(vm): remove unused ELF parser debug helper

### DIFF
--- a/vm/src/elf/parser.rs
+++ b/vm/src/elf/parser.rs
@@ -428,29 +428,6 @@ fn parse_precompile_metadata(
     Ok(precompiles)
 }
 
-#[allow(dead_code)]
-fn debug_segment_info(segment: &ProgramHeader, section_map: &HashMap<&str, (u64, u64)>) {
-    println!("Program Header Information:");
-    println!("  Segment Type: 0x{:08x}", segment.p_type);
-    println!("  File Offset: 0x{:016x}", segment.p_offset);
-    println!("  Virtual Address: 0x{:016x}", segment.p_vaddr);
-    println!("  Physical Address: 0x{:016x}", segment.p_paddr);
-    println!("  File Size: {} bytes", segment.p_filesz);
-    println!("  Memory Size: {} bytes", segment.p_memsz);
-    println!("  Flags: 0x{:08x}", segment.p_flags);
-    println!("  Alignment: 0x{:016x}", segment.p_align);
-    println!(
-        "  LOADABLE: 0x{:08x} -> 0x{:08x}",
-        segment.p_offset,
-        segment.p_offset + segment.p_filesz
-    );
-
-    for (key, (start, end)) in section_map {
-        if !(*end < segment.p_offset || *start > segment.p_offset + segment.p_filesz) {
-            println!("Section {}: 0x{:08x} -> 0x{:08x}", key, start, end);
-        }
-    }
-}
 
 /// Parses the segments of an ELF file and extracts relevant information.
 ///
@@ -489,9 +466,6 @@ pub fn parse_segments(elf: &ElfBytes<LittleEndian>, data: &[u8]) -> Result<Parse
         .iter()
         .filter(|x| x.p_type == abi::PT_LOAD || x.p_type == abi::PT_NOTE)
     {
-        // TODO: Uncomment this when we need to debug the segment info
-        // #[cfg(debug_assertions)]
-        // debug_segment_info(&segment, &section_map);
         // We assume the executable section (PF_X or .text section) is the first executable segment,
         // thus it has the lower address, we use this information to figure out the base address of the program
         if (segment.p_flags & abi::PF_X) != 0 && base_address > segment.p_vaddr {


### PR DESCRIPTION
eliminate the dead debug_segment_info helper from vm/src/elf/parser.rs, drop the commented-out call so the hot path stays free of unused debugging hooks