### PR TITLE
fix(vm): use checked_mul and checked_add to avoid pre-check overflow

### DIFF
--- a/vm/src/memory/paged_memory.rs
+++ b/vm/src/memory/paged_memory.rs
@@ -104,18 +104,18 @@ impl PagedMemory {
     }
 
     pub fn set_words(&mut self, address: u32, values: &[u32]) -> Result<(), MemoryError> {
-        if address
-            .checked_add(values.len() as u32 * WORD_SIZE as u32)
-            .is_none()
-        {
-            return Err(MemoryError::AddressCalculationOverflow);
-        }
-
         if values.is_empty() {
             return Ok(());
         }
 
-        let end_address = address + values.len() as u32 * WORD_SIZE as u32;
+        let words_len_u32 =
+            u32::try_from(values.len()).map_err(|_| MemoryError::AddressCalculationOverflow)?;
+        let bytes_len = words_len_u32
+            .checked_mul(WORD_SIZE as u32)
+            .ok_or(MemoryError::AddressCalculationOverflow)?;
+        let end_address = address
+            .checked_add(bytes_len)
+            .ok_or(MemoryError::AddressCalculationOverflow)?;
 
         let mut current_address = address;
         let mut current_index = 0;


### PR DESCRIPTION
The previous overflow guard in vm/src/memory/paged_memory.rs::set_words() computed values.len() as u32 * WORD_SIZE as u32 prior to calling checked_add, allowing multiplication to overflow before the check and later recomputing end_address with unchecked addition. This change converts the word count to u32 with u32::try_from, then uses checked_mul to obtain the byte length and checked_add to compute end_address. The checked end_address is reused throughout the function, eliminating the unchecked recomputation. This ensures that any overflow during size or address calculations is caught and reported as MemoryError::AddressCalculationOverflow without relying on debug panics or release-mode wrapping.