### PR TITLE
refactor: remove redundant IO entry constructors

### DIFF
--- a/vm/src/emulator/executor.rs
+++ b/vm/src/emulator/executor.rs
@@ -1161,12 +1161,9 @@ impl Emulator for LinearEmulator {
                 let base_address =
                     self.memory_layout.public_input_start() + i as u32 * WORD_SIZE as u32;
                 let word = word_content.to_le_bytes();
-                word.into_iter()
-                    .enumerate()
-                    .map(move |(j, byte)| MemoryInitializationEntry {
-                        address: base_address + j as u32,
-                        value: byte,
-                    })
+                word.into_iter().enumerate().map(move |(j, byte)| {
+                    MemoryInitializationEntry::new(base_address + j as u32, byte)
+                })
             })
             .collect();
 
@@ -1179,12 +1176,9 @@ impl Emulator for LinearEmulator {
             .flat_map(|(i, word_content)| {
                 let base_address = 0x80 + i as u32 * WORD_SIZE as u32;
                 let word = word_content.to_le_bytes();
-                word.into_iter()
-                    .enumerate()
-                    .map(move |(j, byte)| MemoryInitializationEntry {
-                        address: base_address + j as u32,
-                        value: byte,
-                    })
+                word.into_iter().enumerate().map(move |(j, byte)| {
+                    MemoryInitializationEntry::new(base_address + j as u32, byte)
+                })
             });
 
         let mut rom_count = 0;
@@ -1196,7 +1190,7 @@ impl Emulator for LinearEmulator {
                     mem_ro
                         .addr_val_bytes_iter()
                         .inspect(|_| rom_count += 1)
-                        .map(|(address, value)| MemoryInitializationEntry { address, value })
+                        .map(|(address, value)| MemoryInitializationEntry::new(address, value))
                         .collect::<Vec<_>>()
                         .into_iter()
                 }
@@ -1205,7 +1199,7 @@ impl Emulator for LinearEmulator {
                     mem_ro
                         .addr_val_bytes_iter()
                         .inspect(|_| rom_count += 1)
-                        .map(|(address, value)| MemoryInitializationEntry { address, value })
+                        .map(|(address, value)| MemoryInitializationEntry::new(address, value))
                         .collect::<Vec<_>>()
                         .into_iter()
                 }
@@ -1214,7 +1208,7 @@ impl Emulator for LinearEmulator {
                     mem_na
                         .addr_val_bytes_iter()
                         .inspect(|_| rom_count += 1)
-                        .map(|(address, value)| MemoryInitializationEntry { address, value })
+                        .map(|(address, value)| MemoryInitializationEntry::new(address, value))
                         .collect::<Vec<_>>()
                         .into_iter()
                 }
@@ -1223,7 +1217,7 @@ impl Emulator for LinearEmulator {
                     mem_na
                         .addr_val_bytes_iter()
                         .inspect(|_| rom_count += 1)
-                        .map(|(address, value)| MemoryInitializationEntry { address, value })
+                        .map(|(address, value)| MemoryInitializationEntry::new(address, value))
                         .collect::<Vec<_>>()
                         .into_iter()
                 }
@@ -1235,9 +1229,11 @@ impl Emulator for LinearEmulator {
             .as_byte_slice()
             .iter()
             .enumerate()
-            .map(|(offset, byte)| MemoryInitializationEntry {
-                address: offset as u32 + self.initial_static_ram_image.base(),
-                value: *byte,
+            .map(|(offset, byte)| {
+                MemoryInitializationEntry::new(
+                    offset as u32 + self.initial_static_ram_image.base(),
+                    *byte,
+                )
             })
             .collect();
 


### PR DESCRIPTION
Removed the inherent new constructors from MemoryInitializationEntry and PublicOutputEntry, which duplicated the implementations generated by the io! macro via the IOEntry trait. All internal call sites that used MemoryInitializationEntry::new are updated to use explicit struct literals instead, keeping construction simple and consistent while avoiding two parallel ways to create the same types.