### PR TITLE
perf: reuse pending_logup capacity in LogupTraceBuilder

### DIFF
--- a/prover2/machine/src/lookups/logup_trace_builder.rs
+++ b/prover2/machine/src/lookups/logup_trace_builder.rs
@@ -86,7 +86,7 @@ impl LogupTraceBuilder {
             Self::iter_logup_fractions(self.log_size, relation, &mult_columns, mult_expr, tuple);
 
         if self.pending_logup.is_empty() {
-            self.pending_logup = frac_iter.collect();
+            self.pending_logup.extend(frac_iter);
         } else {
             let mut logup_col_gen = self.logup_trace_gen.new_col();
 


### PR DESCRIPTION
Use the preallocated capacity of LogupTraceBuilder::pending_logup by extending it instead of replacing the Vec with a newly collected one. This removes an unnecessary allocation on the first call and avoids discarding the existing buffer, while preserving the existing behavior of logup trace generation.