### PR TITLE
refactor(vm): remove redundant clone in add_fixed macro

### DIFF
--- a/vm/src/memory/unified.rs
+++ b/vm/src/memory/unified.rs
@@ -212,7 +212,7 @@ macro_rules! add_fixed {
                 return Err(MemoryError::MemoryOverlap);
             }
 
-            self.meta.insert(rng.clone(), Modes::$mode);
+            self.meta.insert(rng, Modes::$mode);
 
             let idx = self.$store.len();
             self.$map.insert(rng, idx);


### PR DESCRIPTION
Removes unnecessary `.clone()` call on `Range<u32>` in the `add_fixed!` macro.