### PR TITLE
perf(vm): Remove redundant clone in syscall write logging

### DIFF
--- a/vm/src/system/syscall.rs
+++ b/vm/src/system/syscall.rs
@@ -163,7 +163,7 @@ impl SyscallInstruction {
             let buffer = memory.read_bytes(buf_addr, count as _)?;
 
             if let Some(logger) = logs {
-                logger.push(buffer.clone());
+                logger.push(buffer);
             } else {
                 print!("{}", String::from_utf8_lossy(&buffer));
             }


### PR DESCRIPTION
Removes unnecessary `clone()` call when pushing buffer to syscall write logs, eliminating redundant memory allocation and data copying.