### PR TITLE
perf: Remove unnecessary allocations in syscall handlers

### DIFF
--- a/vm/src/system/syscall.rs
+++ b/vm/src/system/syscall.rs
@@ -163,7 +163,7 @@ impl SyscallInstruction {
             let buffer = memory.read_bytes(buf_addr, count as _)?;
 
             if let Some(logger) = logs {
-                logger.push(buffer.clone());
+                logger.push(buffer);
             } else {
                 print!("{}", String::from_utf8_lossy(&buffer));
             }
@@ -200,10 +200,11 @@ impl SyscallInstruction {
 
         // Convert buffer to string and split it into marker and function name
         let label = String::from_utf8_lossy(&buf).to_string();
-        let (marker, fn_name) = label
-            .split_once('#')
-            .ok_or_else(|| VMErrorKind::InvalidProfileLabel(label.clone()))?
-            .to_owned();
+        let (marker, fn_name) = match label.split_once('#') {
+            Some(parts) => parts,
+            None => return Err(VMErrorKind::InvalidProfileLabel(label))?,
+        };
+        let (marker, fn_name) = (marker.to_owned(), fn_name.to_owned());
 
         // Ensure the marker is either '^' (start) or '$' (end)
         if !matches!(marker, "^" | "$") {

--- a/vm/src/system/syscall.rs
+++ b/vm/src/system/syscall.rs
@@ -204,7 +204,6 @@ impl SyscallInstruction {
             Some(parts) => parts,
             None => return Err(VMErrorKind::InvalidProfileLabel(label))?,
         };
-        let (marker, fn_name) = (marker.to_owned(), fn_name.to_owned());
 
         // Ensure the marker is either '^' (start) or '$' (end)
         if !matches!(marker, "^" | "$") {


### PR DESCRIPTION
Eliminates redundant clones and allocations in syscall implementation by leveraging Rust's move semantics more effectively.