### PR TITLE
fix: correct memory parameter documentation in evaluator

### DIFF
--- a/common/src/cpu/traits.rs
+++ b/common/src/cpu/traits.rs
@@ -94,7 +94,7 @@ pub trait InstructionExecutor {
     ///
     /// # Arguments
     /// * `cpu` - Mutable reference to the CPU state.
-    /// * `memory` - Immutable reference to the memory subsystem.
+    /// * `memory` - Mutable reference to the memory subsystem.
     /// * `ins` - The instruction to be decoded.
     ///
     /// # Returns


### PR DESCRIPTION
The comment stated memory was an immutable reference, but the method signature requires &mut impl MemoryProcessor since memory_write needs mutable access.