### PR TITLE
perf(vm): remove redundant clone in unified memory macro

### DIFF
--- a/vm/src/memory/unified.rs
+++ b/vm/src/memory/unified.rs
@@ -212,7 +212,7 @@ macro_rules! add_fixed {
                 return Err(MemoryError::MemoryOverlap);
             }
 
-            self.meta.insert(rng.clone(), Modes::$mode);
+            self.meta.insert(rng, Modes::$mode);
 
             let idx = self.$store.len();
             self.$map.insert(rng, idx);


### PR DESCRIPTION
Removes unnecessary `.clone()` call in the `add_fixed!` macro within `UnifiedMemory`.