### PR TITLE
perf(vm): optimize public input buffer allocation in HarvardEmulator

### DIFF
--- a/vm/src/emulator/executor.rs
+++ b/vm/src/emulator/executor.rs
@@ -467,8 +467,10 @@ impl HarvardEmulator {
             .unwrap();
 
         // Add the public input length to the beginning of the public input.
-        let len_bytes = (public_input.len()) as u32;
-        let public_input_with_len = [&len_bytes.to_le_bytes()[..], public_input].concat();
+        let len_bytes = public_input.len() as u32;
+        let mut public_input_with_len = Vec::with_capacity(WORD_SIZE + public_input.len());
+        public_input_with_len.extend_from_slice(&len_bytes.to_le_bytes());
+        public_input_with_len.extend_from_slice(public_input);
 
         let mut emulator = Self {
             executor: Executor {


### PR DESCRIPTION
Replaces `concat()` with pre-allocated buffer when building public input with length prefix in `HarvardEmulator::from_elf`.