### PR TITLE
perf(vm): Remove redundant clone in add_fixed macro

### DIFF
--- a/vm/src/memory/unified.rs
+++ b/vm/src/memory/unified.rs
@@ -212,7 +212,8 @@ macro_rules! add_fixed {
                 return Err(MemoryError::MemoryOverlap);
             }
 
-            self.meta.insert(rng.clone(), Modes::$mode);
+            // Range<u32> is Copy, so cloning is unnecessary.
+            self.meta.insert(rng, Modes::$mode);
 
             let idx = self.$store.len();
             self.$map.insert(rng, idx);


### PR DESCRIPTION
Eliminates unnecessary `.clone()` call in the `add_fixed!` macro within `UnifiedMemory`.