### PR TITLE
refactor(vm): simplify debug logs initialization in emulator finalize methods

### DIFF
--- a/vm/src/emulator/executor.rs
+++ b/vm/src/emulator/executor.rs
@@ -467,8 +467,10 @@ impl HarvardEmulator {
             .unwrap();
 
         // Add the public input length to the beginning of the public input.
-        let len_bytes = (public_input.len()) as u32;
-        let public_input_with_len = [&len_bytes.to_le_bytes()[..], public_input].concat();
+        let len_bytes = public_input.len() as u32;
+        let mut public_input_with_len = Vec::with_capacity(WORD_SIZE + public_input.len());
+        public_input_with_len.extend_from_slice(&len_bytes.to_le_bytes());
+        public_input_with_len.extend_from_slice(public_input);
 
         let mut emulator = Self {
             executor: Executor {
@@ -706,11 +708,7 @@ impl Emulator for HarvardEmulator {
             })
             .collect();
 
-        let debug_logs: Vec<Vec<u8>> = if self.get_executor().logs.is_some() {
-            self.get_executor().logs.clone().unwrap()
-        } else {
-            Vec::new()
-        };
+        let debug_logs = self.get_executor().logs.clone().unwrap_or_default();
 
         let input_size = ro_initial_memory.len() + rw_initial_memory.len() + input_memory.len();
         let tracked_ram_size = self
@@ -1237,11 +1235,7 @@ impl Emulator for LinearEmulator {
             })
             .collect();
 
-        let debug_logs: Vec<Vec<u8>> = if self.get_executor().logs.is_some() {
-            self.get_executor().logs.clone().unwrap()
-        } else {
-            Vec::new()
-        };
+        let debug_logs = self.get_executor().logs.clone().unwrap_or_default();
 
         let associated_data = self
             .memory


### PR DESCRIPTION
Refactored redundant conditional logic for debug logs initialization in both HarvardEmulator and LinearEmulator finalize methods, replacing verbose if-else blocks with idiomatic Rust pattern.