### PR TITLE
Refine precompile metadata error formatting

### DIFF
--- a/precompiles/macros/src/generation.rs
+++ b/precompiles/macros/src/generation.rs
@@ -67,7 +67,7 @@ pub(crate) fn generate_statics(paths: &Vec<PrecompilePath>) -> Result<TokenStrea
             Err(e) => {
                 return Err(syn::Error::new(
                     path.as_syn_path().span(),
-                    format!("Failed to serialize metadata for {}", e),
+                    format!("Failed to serialize metadata for {e}"),
                 ));
             }
             Ok(data) => data,


### PR DESCRIPTION
inline format string capture for metadata serialization error message
remove redundant formatting argument in precompile macro generation