### PR TITLE
perf(vm): Remove redundant allocations in private input initialization

### DIFF
--- a/vm/src/emulator/executor.rs
+++ b/vm/src/emulator/executor.rs
@@ -204,7 +204,7 @@ impl Executor {
 
     /// Set or overwrite private input into the private input tape
     fn set_private_input(&mut self, private_input: &[u8]) {
-        self.private_input_tape = VecDeque::<u8>::from(private_input.to_vec());
+        self.private_input_tape = private_input.iter().copied().collect();
     }
 
     /// Set whether to capture logs or print out.
@@ -333,58 +333,6 @@ pub trait Emulator {
         self.get_executor_mut().set_private_input(private_input)
     }
 
-    /// Update and return previous timestamps, but it currently works word-wise, so not used.
-    #[allow(dead_code)]
-    fn manage_timestamps(&mut self, size: &MemAccessSize, address: &u32) -> usize {
-        let half_aligned_address = address & !(WORD_SIZE / 2 - 1) as u32;
-        let full_aligned_address = address & !(WORD_SIZE - 1) as u32;
-
-        let prev = match size {
-            MemAccessSize::Byte => max(
-                *self
-                    .get_executor()
-                    .access_timestamps
-                    .get(address)
-                    .unwrap_or(&0),
-                max(
-                    *self
-                        .get_executor()
-                        .access_timestamps
-                        .get(&half_aligned_address)
-                        .unwrap_or(&0),
-                    *self
-                        .get_executor()
-                        .access_timestamps
-                        .get(&full_aligned_address)
-                        .unwrap_or(&0),
-                ),
-            ),
-            MemAccessSize::HalfWord => max(
-                *self
-                    .get_executor()
-                    .access_timestamps
-                    .get(address)
-                    .unwrap_or(&0),
-                *self
-                    .get_executor()
-                    .access_timestamps
-                    .get(&full_aligned_address)
-                    .unwrap_or(&0),
-            ),
-            MemAccessSize::Word => *self
-                .get_executor()
-                .access_timestamps
-                .get(address)
-                .unwrap_or(&0),
-        };
-
-        let clk = self.get_executor().global_clock;
-        self.get_executor_mut()
-            .access_timestamps
-            .insert(*address, clk);
-        prev
-    }
-
     /// Return a `View` capturing the end-state of the emulator.
     fn finalize(&self) -> View;
 }
@@ -472,7 +420,7 @@ impl HarvardEmulator {
 
         let mut emulator = Self {
             executor: Executor {
-                private_input_tape: VecDeque::<u8>::from(private_input.to_vec()),
+                private_input_tape: private_input.iter().copied().collect(),
                 base_address: elf.base,
                 entrypoint: elf.entry,
                 global_clock: 1, // global_clock = 0 captures initalization for memory records
@@ -975,7 +923,7 @@ impl LinearEmulator {
 
         let mut emulator = Self {
             executor: Executor {
-                private_input_tape: VecDeque::<u8>::from(private_input.to_vec()),
+                private_input_tape: private_input.iter().copied().collect(),
                 base_address: code_start,
                 entrypoint: code_start + (elf.entry - elf.base),
                 global_clock: 1, // global_clock = 0 captures initalization for memory records


### PR DESCRIPTION
This PR eliminates unnecessary intermediate allocations when initializing private_input_tape from byte slices, improving memory efficiency in the emulator initialization path.