### PR TITLE
feat: add `nexus_sdk` extensions support

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -20,5 +20,8 @@ pub mod nvm {
 
 /// Stwo proving
 pub mod stwo {
-    pub use nexus_vm_prover::{prove, verify, Proof, ProvingError, VerificationError};
+    pub use nexus_vm_prover::{
+        prove, prove_with_extensions, verify, verify_with_extensions, ExtensionComponent, Proof,
+        ProvingError, VerificationError,
+    };
 }

--- a/prover/src/lib.rs
+++ b/prover/src/lib.rs
@@ -7,6 +7,8 @@ pub mod components;
 pub mod extensions;
 pub mod trace;
 
+pub use extensions::ExtensionComponent;
+
 pub mod column;
 pub mod traits;
 pub mod virtual_column;
@@ -37,6 +39,35 @@ pub fn verify(proof: Proof, view: &nexus_vm::emulator::View) -> Result<(), Verif
         view.view_associated_data().as_deref().unwrap_or_default(),
         &[
             // preprocessed trace is sensitive to this ordering
+            view.get_ro_initial_memory(),
+            view.get_rw_initial_memory(),
+            view.get_public_input(),
+        ]
+        .concat(),
+        view.get_exit_code(),
+        view.get_public_output(),
+    )
+}
+
+pub fn prove_with_extensions(
+    extensions: &[ExtensionComponent],
+    trace: &impl nexus_vm::trace::Trace,
+    view: &nexus_vm::emulator::View,
+) -> Result<Proof, ProvingError> {
+    machine::Machine::<machine::BaseComponent>::prove_with_extensions(extensions, trace, view)
+}
+
+pub fn verify_with_extensions(
+    extensions: &[ExtensionComponent],
+    proof: Proof,
+    view: &nexus_vm::emulator::View,
+) -> Result<(), VerificationError> {
+    machine::Machine::<machine::BaseComponent>::verify_with_extensions(
+        extensions,
+        proof,
+        view.get_program_memory(),
+        view.view_associated_data().as_deref().unwrap_or_default(),
+        &[
             view.get_ro_initial_memory(),
             view.get_rw_initial_memory(),
             view.get_public_input(),


### PR DESCRIPTION
#### Is this resolving a feature or a bug?

Feature

#### Are there existing issue(s) that this PR would close?

- Closes #589

#### If this PR is not minimal (it could be split into multiple PRs), please explain why the issues are best resolved together.

This PR is minimal.

#### Describe your changes.

Add extensions support to `nexus-sdk`. Users can now use extensions without bypassing the SDK:

```rust
use nexus_sdk::stwo::seq::{Stwo, ExtensionComponent};

let prover = Stwo::new(&elf)?.with_extensions(ExtensionComponent::keccak_extensions());
let (view, proof) = prover.prove_with_input(&input, &())?;
proof.verify_with_extensions(ExtensionComponent::keccak_extensions(), &view)?;
```

Changes:
- `sdk`: Add `Stwo::with_extensions()`, `Proof::verify_with_extensions()`, re-export `ExtensionComponent`
- `prover`/`core`: Expose `prove_with_extensions()`, `verify_with_extensions()`, `ExtensionComponent`

