### PR TITLE
refactor(vm): remove unused debug helper functions from ELF loader tests

### DIFF
--- a/vm/src/elf/loader.rs
+++ b/vm/src/elf/loader.rs
@@ -131,44 +131,10 @@ impl ElfFile {
 mod tests {
     use nexus_common::constants::ELF_TEXT_START;
 
-    use crate::{memory::MemorySegmentImage, read_testing_elf_from_path};
+    use crate::read_testing_elf_from_path;
 
     use super::*;
-    use std::fs::File;
-    use std::io::Write;
-
-    #[allow(dead_code)]
-    fn write_instruction_to_file(instructions: &[u32], file_path: &str) {
-        let mut file = File::create(file_path).unwrap();
-        for &instruction in instructions {
-            file.write_all(&instruction.to_le_bytes()).unwrap();
-        }
-    }
-
-    #[allow(dead_code)]
-    fn write_memory_to_file(memory: &MemorySegmentImage, file_path: &str) {
-        let mut file = File::create(file_path).unwrap();
-        file.write_all(memory.as_byte_slice()).unwrap();
-    }
-
-    #[allow(dead_code)]
-    fn debug_elf_file(elf: &ElfFile, file_path: &str) {
-        dbg!(elf.instructions.len());
-        dbg!(elf.entry);
-        dbg!(elf.base);
-        dbg!(elf.ram_image.len_bytes());
-        dbg!(elf.rom_image.len_bytes());
-
-        // Write elf.instructions to a file
-        write_instruction_to_file(&elf.instructions, &format!("{file_path}.inst.bin"));
-
-        // Write elf.memory_image to a file
-        write_memory_to_file(&elf.ram_image, &format!("{file_path}.mem.bin"));
-
-        // Write elf.readonly_memory_image to a file
-        write_memory_to_file(&elf.rom_image, &format!("{file_path}.rom.bin"));
-    }
-
+    
     #[test]
     fn test_parse_elf_files() {
         // Use llvm-objdump to find what these numbers should be


### PR DESCRIPTION
Removes dead code from the ELF loader test module that was marked with #[allow(dead_code)] attributes.