### PR TITLE
refactor(runtime): Remove unused SYS_OVERWRITE_SP constant

### DIFF
--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -33,9 +33,6 @@ pub(crate) const SYS_READ_PRIVATE_INPUT: u32 = 0x400;
 #[cfg(target_arch = "riscv32")]
 pub(crate) const SYS_CYCLE_COUNT: u32 = 0x401;
 #[cfg(target_arch = "riscv32")]
-#[allow(dead_code)]
-pub(crate) const SYS_OVERWRITE_SP: u32 = 0x402;
-#[cfg(target_arch = "riscv32")]
 pub(crate) const SYS_ALLOC_ALIGNED: u32 = 0x403;
 #[cfg(target_arch = "riscv32")]
 pub(crate) const SYS_PERFORM_HEAP_ALLOCATION: u32 = 0x405;


### PR DESCRIPTION
Removes dead code: the `SYS_OVERWRITE_SP` constant declaration that was never referenced in the codebase.
