### PR TITLE
chore(vm): remove unused debug_segment_info function

### DIFF
--- a/vm/src/elf/parser.rs
+++ b/vm/src/elf/parser.rs
@@ -428,30 +428,6 @@ fn parse_precompile_metadata(
     Ok(precompiles)
 }
 
-#[allow(dead_code)]
-fn debug_segment_info(segment: &ProgramHeader, section_map: &HashMap<&str, (u64, u64)>) {
-    println!("Program Header Information:");
-    println!("  Segment Type: 0x{:08x}", segment.p_type);
-    println!("  File Offset: 0x{:016x}", segment.p_offset);
-    println!("  Virtual Address: 0x{:016x}", segment.p_vaddr);
-    println!("  Physical Address: 0x{:016x}", segment.p_paddr);
-    println!("  File Size: {} bytes", segment.p_filesz);
-    println!("  Memory Size: {} bytes", segment.p_memsz);
-    println!("  Flags: 0x{:08x}", segment.p_flags);
-    println!("  Alignment: 0x{:016x}", segment.p_align);
-    println!(
-        "  LOADABLE: 0x{:08x} -> 0x{:08x}",
-        segment.p_offset,
-        segment.p_offset + segment.p_filesz
-    );
-
-    for (key, (start, end)) in section_map {
-        if !(*end < segment.p_offset || *start > segment.p_offset + segment.p_filesz) {
-            println!("Section {key}: 0x{start:08x} -> 0x{end:08x}");
-        }
-    }
-}
-
 /// Parses the segments of an ELF file and extracts relevant information.
 ///
 /// This function iterates through the LOAD segments of the ELF file, extracting


### PR DESCRIPTION
Removes dead debugging code from the ELF parser module.