### PR TITLE
refactor(sdk): remove redundant PathBuf clone in linker creation

### DIFF
--- a/sdk/src/compile/mod.rs
+++ b/sdk/src/compile/mod.rs
@@ -64,7 +64,7 @@ pub trait Compile {
             fs::create_dir_all(parent)?;
         }
 
-        let mut file = fs::File::create(linker_path.clone())?;
+        let mut file = fs::File::create(&linker_path)?;
         file.write_all(linker_script.as_bytes())?;
 
         Ok(linker_path)


### PR DESCRIPTION
Removes an unnecessary `PathBuf::clone()` call in the `set_linker()` function.
