### PR TITLE
refactor(sdk): remove unnecessary PathBuf clone in File::create call

### DIFF
--- a/sdk/src/legacy/compile.rs
+++ b/sdk/src/legacy/compile.rs
@@ -126,7 +126,7 @@ impl CompileOpts {
             fs::create_dir_all(parent)?;
         }
 
-        let mut file = fs::File::create(linker_path.clone())?;
+        let mut file = fs::File::create(&linker_path)?;
         file.write_all(linker_script.as_bytes())?;
 
         Ok(linker_path)


### PR DESCRIPTION
Removes redundant .clone() call when creating a file in the legacy compiler module. The change eliminates an unnecessary heap allocation without affecting functionality.