### PR TITLE
test: add valid positive and negative J-type immediate encoding tests to encoder

### DIFF
--- a/common/src/riscv/encoder.rs
+++ b/common/src/riscv/encoder.rs
@@ -245,26 +245,41 @@ mod tests {
 
     #[test]
     fn test_j_type_jump_boundaries() {
-        // Test with a large positive jump: JAL x1, +1MB (1048576)
-        let pos_ins = Instruction {
+        // +1MB (1048576 = 2^20) equals the J-type signed minimum (-2^20) in 21-bit
+        // two's-complement, so both produce the same encoding.  This test documents
+        // that property but does NOT exercise a positive/negative distinction.
+        let overflow_ins = Instruction {
             opcode: Opcode::from(BuiltinOpcode::JAL),
             ins_type: InstructionType::JType,
             op_a: 1.into(),
             op_b: 0.into(),
             op_c: 1048576,
         };
-        let encoded_pos = pos_ins.encode();
-        assert_eq!(encoded_pos, 0x800000EF);
+        assert_eq!(overflow_ins.encode(), 0x800000EF);
 
-        // Test with a large negative jump: JAL x1, -1MB (-1048576)
+        // Valid small positive jump: JAL x1, +16
+        // imm[10:1]=8, all other imm bits zero.
+        let pos_ins = Instruction {
+            opcode: Opcode::from(BuiltinOpcode::JAL),
+            ins_type: InstructionType::JType,
+            op_a: 1.into(),
+            op_b: 0.into(),
+            op_c: 16,
+        };
+        let encoded_pos = pos_ins.encode();
+        assert_eq!(encoded_pos, 0x10000EF);
+
+        // Valid small negative jump: JAL x1, -8
+        // imm=-8: imm[20]=1, imm[19:12]=0xFF, imm[11]=1, imm[10:1]=0x3FC
+        // Expected: 0x80000000|0x7F800000|0x100000|0xFF000|0x80|0x6F = 0xFF9FF0EF
         let neg_ins = Instruction {
             opcode: Opcode::from(BuiltinOpcode::JAL),
             ins_type: InstructionType::JType,
             op_a: 1.into(),
             op_b: 0.into(),
-            op_c: -1048576i32 as u32,
+            op_c: -8i32 as u32,
         };
         let encoded_neg = neg_ins.encode();
-        assert_eq!(encoded_neg, 0x800000EF);
+        assert_eq!(encoded_neg, 0xFF9FF0EF);
     }
 }


### PR DESCRIPTION
## Problem

`test_j_type_jump_boundaries` uses `op_c = 1048576` (2^20) for the “positive” case and `op_c = -1048576i32 as u32` for the “negative” case, then asserts both produce `0x800000EF`.

This is not a sign error — it is a two’s-complement identity: 2^20 equals the minimum representable value in a 21-bit signed immediate field (the J-type field width), so the two `op_c` values are bit-for-bit identical. **The test never exercises any valid negative jump offset**, leaving the encoder’s negative-immediate path entirely untested.

The B-type test (`test_b_type_branch_offsets`) correctly tests a negative offset (`BEQ x1, x2, -16`); the J-type test should do the same.

## Fix

Add two concrete test cases that cover valid positive and negative J-type immediates:

| Instruction | op_c | Expected encoding |
|---|---|---|
| `JAL x1, +16` | 16 | `0x10000EF` |
| `JAL x1, -8` | `-8i32 as u32` | `0xFF9FF0EF` |

Expected values are derived from the RISC-V J-type bit-field layout (spec §2.5) and verified manually. The original ±1 MB case is retained with a comment explaining the two’s-complement identity.