### PR TITLE
fix: add debug_assert for IType/SType 12-bit immediate range in Instruction::new_ir

### DIFF
--- a/common/src/riscv/instruction.rs
+++ b/common/src/riscv/instruction.rs
@@ -76,6 +76,17 @@ impl Instruction {
             );
         }
 
+        if ins_type == InstructionType::IType || ins_type == InstructionType::SType {
+            // I-type and S-type immediates are 12-bit signed values in [-2048, 2047].
+            // Values outside this range are silently truncated during encoding, producing
+            // instructions that do not match the intent of the caller.
+            let imm = op_c as i32;
+            debug_assert!(
+                (-2048..=2047).contains(&imm),
+                "IType/SType immediate must be a 12-bit signed value in [-2048, 2047], got {imm}"
+            );
+        }
+
         Self::new(
             opcode,
             Register::from(op_a),


### PR DESCRIPTION
## Problem

`Instruction::new_ir` validates R-type and `ITypeShamt` operands:

```rust
if ins_type == InstructionType::RType || ins_type == InstructionType::ITypeShamt {
    debug_assert!(op_c <= 0x1F, ...);
}
```

But there is **no validation for IType or SType immediates**, even though both have a 12-bit signed range of `[-2048, 2047]`.

When `op_c` exceeds this range, `encode_i_type` silently truncates it:

```rust
let imm = (instruction.op_c & 0xFFF) << 20; // upper bits discarded
```

A call such as `Instruction::new_ir(ADDI, rd, rs1, 4096)` stores `op_c = 4096` but encodes as `op_c = 0`, producing an instruction that differs silently from the caller’s intent. Any chip that reads `op_c` directly (rather than re-encoding) will see the unclamped value, potentially causing the prover to generate a trace that does not satisfy its own constraints.

## Fix

Add a `debug_assert!` for `IType` and `SType` immediates, matching the existing pattern for `RType`/`ITypeShamt`:

```rust
if ins_type == InstructionType::IType || ins_type == InstructionType::SType {
    let imm = op_c as i32;
    debug_assert!((-2048..=2047).contains(&imm), ...);
}
```

The assert fires only in debug builds, so there is no runtime cost in release.