### PR TITLE
fix: replace panicking .expect() / assert! on PC access counter overflow in ProgramMemCheckChip

### DIFF
--- a/prover/src/chips/memory_check/program_mem_check.rs
+++ b/prover/src/chips/memory_check/program_mem_check.rs
@@ -59,9 +59,14 @@ impl MachineChip for ProgramMemCheckChip {
                 .get(&pc)
                 .unwrap_or(&0u32);
             traces.fill_columns(row_idx, *last_access_counter, Column::ProgCtrPrev);
-            let new_access_counter = last_access_counter
-                .checked_add(1)
-                .expect("access counter overflow");
+            // Increment access counter. An overflow indicates either an adversarially
+            // crafted program (tight-loop exceeding u32::MAX iterations at the same PC)
+            // or a prover bug. Return early instead of panicking so the process stays
+            // alive; the constraint system's carry-overflow constraint will reject
+            // the resulting trace as unsound.
+            let Some(new_access_counter) = last_access_counter.checked_add(1) else {
+                return;
+            };
             traces.fill_columns(row_idx, new_access_counter, Column::ProgCtrCur);
             // Compute and fill carry flags
             let last_counter_bytes = last_access_counter.to_le_bytes();
@@ -73,8 +78,9 @@ impl MachineChip for ProgramMemCheckChip {
                 (incremented_bytes[i], carry_bits[i]) =
                     last_counter_bytes[i].overflowing_add(carry_bits[i - 1] as u8);
             }
-            assert!(!carry_bits[WORD_SIZE - 1]); // Check against overflow
-            assert_eq!(u32::from_le_bytes(incremented_bytes), new_access_counter);
+            // These are debug-only checks: checked_add above already guarantees no overflow.
+            debug_assert!(!carry_bits[WORD_SIZE - 1], "access counter carry overflow");
+            debug_assert_eq!(u32::from_le_bytes(incremented_bytes), new_access_counter);
             traces.fill_columns(
                 row_idx,
                 [carry_bits[1], carry_bits[3]],


### PR DESCRIPTION
## Problem

`ProgramMemCheckChip::fill_main_trace` panics in two places when a PC is accessed more than `u32::MAX` times:

```rust
let new_access_counter = last_access_counter
    .checked_add(1)
    .expect("access counter overflow"); // panic 1
// ...
assert!(!carry_bits[WORD_SIZE - 1]); // panic 2 — redundant overflow check
```

An adversarially crafted program with a tight infinite loop (`j 0`) will eventually push the counter past `u32::MAX`, triggering an unconditional panic that **kills the prover process**. This is a denial-of-service vector: a malicious guest program can crash the prover without producing a verifiable trace.

## Fix

- Replace `.expect()` with a `let…else` that returns early on overflow. The constraint system's carry-overflow constraint (`Don't allow overflow` in `add_constraints`) will reject the resulting trace as unsound — no panic required.
- Downgrade the two redundant `assert!` calls to `debug_assert!` since `checked_add` already guarantees the invariant on the non-overflow path.