### PR TITLE
prover: enforce load/store memory alignment in AIR

### DIFF
--- a/prover/src/chips/instructions/i/load_store.rs
+++ b/prover/src/chips/instructions/i/load_store.rs
@@ -122,9 +122,7 @@ impl MachineChip for LoadStoreChip {
         traces.fill_columns(row_idx, ram_base_address, Column::RamBaseAddr);
 
         let alignment_divisor: Option<u8> = match vm_step.step.instruction.opcode.builtin() {
-            Some(BuiltinOpcode::LH) | Some(BuiltinOpcode::LHU) | Some(BuiltinOpcode::SH) => {
-                Some(2)
-            }
+            Some(BuiltinOpcode::LH) | Some(BuiltinOpcode::LHU) | Some(BuiltinOpcode::SH) => Some(2),
             Some(BuiltinOpcode::LW) | Some(BuiltinOpcode::SW) => Some(4),
             _ => None,
         };
@@ -488,8 +486,7 @@ impl MachineChip for LoadStoreChip {
 
             eval.add_constraint(
                 is_word_access
-                    * (ram_base_addr[0].clone()
-                        - alignment_quotient * BaseField::from(4u32)),
+                    * (ram_base_addr[0].clone() - alignment_quotient * BaseField::from(4u32)),
             );
         }
         let carry_flag = trace_eval!(trace_eval, Column::CarryFlag);

--- a/prover/src/chips/instructions/i/load_store.rs
+++ b/prover/src/chips/instructions/i/load_store.rs
@@ -120,6 +120,24 @@ impl MachineChip for LoadStoreChip {
             add_with_carries(value_a, offset)
         };
         traces.fill_columns(row_idx, ram_base_address, Column::RamBaseAddr);
+
+        let alignment_divisor: Option<u8> = match vm_step.step.instruction.opcode.builtin() {
+            Some(BuiltinOpcode::LH) | Some(BuiltinOpcode::LHU) | Some(BuiltinOpcode::SH) => {
+                Some(2)
+            }
+            Some(BuiltinOpcode::LW) | Some(BuiltinOpcode::SW) => Some(4),
+            _ => None,
+        };
+        if let Some(divisor) = alignment_divisor {
+            // Witness data only: malformed traces must be rejected by AIR
+            // constraints, not by panicking during trace construction.
+            traces.fill_columns(
+                row_idx,
+                ram_base_address[0] / divisor,
+                Column::RamBaseAddrAlignmentQuotient,
+            );
+        }
+
         let carry_bits = [carry_bits[1], carry_bits[3]];
         traces.fill_columns(row_idx, carry_bits, Column::CarryFlag);
         let clk = row_idx as u32 + 1;
@@ -447,6 +465,33 @@ impl MachineChip for LoadStoreChip {
         eval.add_constraint(helper4[WORD_SIZE - 1].clone() * ram3_4_accessed.clone());
 
         let ram_base_addr = trace_eval!(trace_eval, Column::RamBaseAddr);
+        {
+            let [is_lh] = trace_eval!(trace_eval, IsLh);
+            let [is_lhu] = trace_eval!(trace_eval, IsLhu);
+            let [is_lw] = trace_eval!(trace_eval, IsLw);
+            let [is_sh] = trace_eval!(trace_eval, IsSh);
+            let [is_sw] = trace_eval!(trace_eval, IsSw);
+            let [alignment_quotient] =
+                trace_eval!(trace_eval, Column::RamBaseAddrAlignmentQuotient);
+
+            let is_halfword_access = is_lh + is_lhu + is_sh;
+            let is_word_access = is_lw + is_sw;
+
+            // Close the VM/AIR semantic gap: the runtime memory layer rejects
+            // unaligned halfword and word accesses, and these constraints force
+            // the proved effective address to obey the same rule.
+            eval.add_constraint(
+                is_halfword_access
+                    * (ram_base_addr[0].clone()
+                        - alignment_quotient.clone() * BaseField::from(2u32)),
+            );
+
+            eval.add_constraint(
+                is_word_access
+                    * (ram_base_addr[0].clone()
+                        - alignment_quotient * BaseField::from(4u32)),
+            );
+        }
         let carry_flag = trace_eval!(trace_eval, Column::CarryFlag);
         let value_b = trace_eval!(trace_eval, Column::ValueB);
         let value_c = trace_eval!(trace_eval, Column::ValueC);
@@ -1077,6 +1122,60 @@ mod test {
             view.get_public_output(),
         )
         .unwrap();
+    }
+
+    fn alignment_trace(op: Column, address: u32, quotient: u8) -> TracesBuilder {
+        let mut traces = TracesBuilder::new(LOG_SIZE);
+
+        traces.fill_columns(0, true, op);
+        traces.fill_columns(0, address, Column::RamBaseAddr);
+        traces.fill_columns(0, quotient, Column::RamBaseAddrAlignmentQuotient);
+
+        match op {
+            Column::IsSh | Column::IsSw => {
+                traces.fill_columns(0, address, Column::ValueA);
+                traces.fill_columns(0, 0u32, Column::ValueB);
+            }
+            _ => {
+                traces.fill_columns(0, 0u32, Column::ValueA);
+                traces.fill_columns(0, address, Column::ValueB);
+            }
+        }
+
+        traces
+    }
+
+    fn assert_alignment_constraints_reject(op: Column, address: u32, quotient: u8) {
+        let traces = alignment_trace(op, address, quotient);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            assert_chip::<LoadStoreChip>(traces, None);
+        }));
+
+        assert!(
+            result.is_err(),
+            "unaligned load/store trace unexpectedly satisfied LoadStoreChip constraints"
+        );
+    }
+
+    #[test]
+    fn test_unaligned_lh_rejected_in_air() {
+        assert_alignment_constraints_reject(Column::IsLh, 0x0000_1001, 0);
+    }
+
+    #[test]
+    fn test_unaligned_lw_rejected_in_air() {
+        assert_alignment_constraints_reject(Column::IsLw, 0x0000_1002, 0);
+    }
+
+    #[test]
+    fn test_issue_605_unaligned_halfword_store_rejected_in_air() {
+        assert_alignment_constraints_reject(Column::IsSh, 0x0000_1001, 0);
+    }
+
+    #[test]
+    fn test_aligned_lh_and_lw_accepted_in_air() {
+        assert_chip::<LoadStoreChip>(alignment_trace(Column::IsLh, 0x0000_1002, 1), None);
+        assert_chip::<LoadStoreChip>(alignment_trace(Column::IsLw, 0x0000_1004, 1), None);
     }
 
     #[test]

--- a/prover/src/chips/instructions/i/load_store.rs
+++ b/prover/src/chips/instructions/i/load_store.rs
@@ -1160,6 +1160,11 @@ mod test {
     }
 
     #[test]
+    fn test_unaligned_lhu_rejected_in_air() {
+        assert_alignment_constraints_reject(Column::IsLhu, 0x0000_1001, 0);
+    }
+
+    #[test]
     fn test_unaligned_lw_rejected_in_air() {
         assert_alignment_constraints_reject(Column::IsLw, 0x0000_1002, 0);
     }
@@ -1170,9 +1175,17 @@ mod test {
     }
 
     #[test]
-    fn test_aligned_lh_and_lw_accepted_in_air() {
+    fn test_issue_605_unaligned_word_store_rejected_in_air() {
+        assert_alignment_constraints_reject(Column::IsSw, 0x0000_1002, 0);
+    }
+
+    #[test]
+    fn test_aligned_halfword_and_word_accesses_accepted_in_air() {
         assert_chip::<LoadStoreChip>(alignment_trace(Column::IsLh, 0x0000_1002, 1), None);
+        assert_chip::<LoadStoreChip>(alignment_trace(Column::IsLhu, 0x0000_1002, 1), None);
         assert_chip::<LoadStoreChip>(alignment_trace(Column::IsLw, 0x0000_1004, 1), None);
+        assert_chip::<LoadStoreChip>(alignment_trace(Column::IsSh, 0x0000_1002, 1), None);
+        assert_chip::<LoadStoreChip>(alignment_trace(Column::IsSw, 0x0000_1004, 1), None);
     }
 
     #[test]

--- a/prover/src/chips/range_check/range128.rs
+++ b/prover/src/chips/range_check/range128.rs
@@ -71,6 +71,20 @@ impl MachineChip for Range128Chip {
         fill_main_col(qt_aux, is_lh, side_note);
         let [is_lb] = traces.column(row_idx, Column::IsLb);
         fill_main_col(qt_aux, is_lb, side_note);
+
+        let [alignment_quotient] =
+            traces.column(row_idx, Column::RamBaseAddrAlignmentQuotient);
+        let [is_lh_alignment] = traces.column(row_idx, Column::IsLh);
+        let [is_lhu] = traces.column(row_idx, Column::IsLhu);
+        let [is_lw] = traces.column(row_idx, Column::IsLw);
+        let [is_sh] = traces.column(row_idx, Column::IsSh);
+        let [is_sw] = traces.column(row_idx, Column::IsSw);
+        let alignment_selector = is_lh_alignment + is_lhu + is_lw + is_sh + is_sw;
+
+        // q is used by LoadStoreChip to prove addr_low = 2*q or addr_low = 4*q.
+        // Keep q in [0, 127], so unaligned addresses cannot be represented by
+        // arbitrary field elements such as 1/2 or 3/4.
+        fill_main_col(alignment_quotient, alignment_selector, side_note);
     }
     /// Fills the whole interaction trace in one-go using SIMD in the stwo-usual way
     ///
@@ -121,6 +135,23 @@ impl MachineChip for Range128Chip {
         check_col(
             qt_aux,
             &[is_lh, is_lb],
+            original_traces.log_size(),
+            logup_trace_gen,
+            lookup_element,
+        );
+
+        let [alignment_quotient] =
+            original_traces.get_base_column(Column::RamBaseAddrAlignmentQuotient);
+        let [is_lh_alignment] = original_traces.get_base_column(Column::IsLh);
+        let [is_lhu] = original_traces.get_base_column(Column::IsLhu);
+        let [is_lw] = original_traces.get_base_column(Column::IsLw);
+        let [is_sh] = original_traces.get_base_column(Column::IsSh);
+        let [is_sw] = original_traces.get_base_column(Column::IsSw);
+        let alignment_selectors = &[is_lh_alignment, is_lhu, is_lw, is_sh, is_sw];
+
+        check_col(
+            alignment_quotient,
+            alignment_selectors,
             original_traces.log_size(),
             logup_trace_gen,
             lookup_element,
@@ -179,6 +210,21 @@ impl MachineChip for Range128Chip {
             lookup_elements,
             numerator.into(),
             &[qt_aux],
+        ));
+
+        let [alignment_quotient] =
+            trace_eval.column_eval(Column::RamBaseAddrAlignmentQuotient);
+        let [is_lh_alignment] = trace_eval.column_eval(Column::IsLh);
+        let [is_lhu] = trace_eval.column_eval(Column::IsLhu);
+        let [is_lw] = trace_eval.column_eval(Column::IsLw);
+        let [is_sh] = trace_eval.column_eval(Column::IsSh);
+        let [is_sw] = trace_eval.column_eval(Column::IsSw);
+        let alignment_selector = is_lh_alignment + is_lhu + is_lw + is_sh + is_sw;
+
+        eval.add_to_relation(RelationEntry::new(
+            lookup_elements,
+            alignment_selector.into(),
+            &[alignment_quotient],
         ));
     }
 }

--- a/prover/src/chips/range_check/range128.rs
+++ b/prover/src/chips/range_check/range128.rs
@@ -357,4 +357,54 @@ mod test {
             ext.generate_interaction_trace(component_trace, &side_note, &lookup_elements);
         assert_ne!(claimed_sum + claimed_sum_2, SecureField::zero());
     }
+
+    #[test]
+    fn test_alignment_quotient_is_range_checked() {
+        const LOG_SIZE: u32 = PreprocessedBuilder::MIN_LOG_SIZE;
+        let (config, twiddles) = test_params(LOG_SIZE);
+        let mut traces = TracesBuilder::new(LOG_SIZE);
+        let program_info = ProgramInfo::dummy();
+        let program_trace_ref = ProgramTraceRef {
+            program_memory: &program_info,
+            init_memory: Default::default(),
+            exit_code: Default::default(),
+            public_output: Default::default(),
+        };
+        let program_traces = ProgramTracesBuilder::new(LOG_SIZE, program_trace_ref);
+        let mut side_note = SideNote::new(&program_traces, &HarvardEmulator::default().finalize());
+
+        for row_idx in 0..(1 << LOG_SIZE) {
+            traces.fill_columns(row_idx, true, Column::IsLw);
+            traces.fill_columns(row_idx, 0u8, Column::RamBaseAddrAlignmentQuotient);
+
+            Range128Chip::fill_main_trace(
+                &mut traces,
+                row_idx,
+                &Some(ProgramStep::default()),
+                &mut side_note,
+                &ExtensionsConfig::default(),
+            );
+        }
+
+        *traces.column_mut::<{ Column::RamBaseAddrAlignmentQuotient.size() }>(
+            0,
+            Column::RamBaseAddrAlignmentQuotient,
+        )[0] = BaseField::from(128u32);
+
+        let CommittedTraces {
+            claimed_sum,
+            lookup_elements,
+            ..
+        } = commit_traces::<Range128Chip>(config, &twiddles, &traces.finalize(), None);
+
+        let ext = ExtensionComponent::multiplicity128();
+        let component_trace = ext.generate_component_trace(
+            128u32.trailing_zeros(),
+            program_trace_ref,
+            &mut side_note,
+        );
+        let (_, claimed_sum_2) =
+            ext.generate_interaction_trace(component_trace, &side_note, &lookup_elements);
+        assert_ne!(claimed_sum + claimed_sum_2, SecureField::zero());
+    }
 }

--- a/prover/src/chips/range_check/range128.rs
+++ b/prover/src/chips/range_check/range128.rs
@@ -72,8 +72,7 @@ impl MachineChip for Range128Chip {
         let [is_lb] = traces.column(row_idx, Column::IsLb);
         fill_main_col(qt_aux, is_lb, side_note);
 
-        let [alignment_quotient] =
-            traces.column(row_idx, Column::RamBaseAddrAlignmentQuotient);
+        let [alignment_quotient] = traces.column(row_idx, Column::RamBaseAddrAlignmentQuotient);
         let [is_lh_alignment] = traces.column(row_idx, Column::IsLh);
         let [is_lhu] = traces.column(row_idx, Column::IsLhu);
         let [is_lw] = traces.column(row_idx, Column::IsLw);
@@ -212,8 +211,7 @@ impl MachineChip for Range128Chip {
             &[qt_aux],
         ));
 
-        let [alignment_quotient] =
-            trace_eval.column_eval(Column::RamBaseAddrAlignmentQuotient);
+        let [alignment_quotient] = trace_eval.column_eval(Column::RamBaseAddrAlignmentQuotient);
         let [is_lh_alignment] = trace_eval.column_eval(Column::IsLh);
         let [is_lhu] = trace_eval.column_eval(Column::IsLhu);
         let [is_lw] = trace_eval.column_eval(Column::IsLw);

--- a/prover/src/column.rs
+++ b/prover/src/column.rs
@@ -474,6 +474,11 @@ pub enum Column {
     /// The starting address of the read-write memory access
     #[size = 4]
     RamBaseAddr,
+    /// Quotient of the least-significant byte of `RamBaseAddr` by the required
+    /// alignment. Used only by load/store alignment AIR constraints: divided by
+    /// 2 on halfword accesses and by 4 on word accesses.
+    #[size = 1]
+    RamBaseAddrAlignmentQuotient,
     /// The new value of the read-write memory at RamBaseAddr, if accessed
     #[size = 1]
     Ram1ValCur,


### PR DESCRIPTION
## Context

Fixes #605.

The VM rejects unaligned halfword and word memory accesses, but the load/store AIR did not enforce that same rule. That meant a forged trace could describe memory behavior that the VM itself would reject.

This PR makes the load/store AIR enforce the same alignment semantics as the VM for:

- `LH`, `LHU`, `SH` halfword accesses
- `LW`, `SW` word accesses

## What changed

- Added `RamBaseAddrAlignmentQuotient`, a small witness for the low byte of `RamBaseAddr` divided by the required alignment.
- Filled that witness only for halfword and word load/store rows.
- Added `LoadStoreChip` constraints so:
  - halfword rows must satisfy `addr_low = 2 * q`
  - word rows must satisfy `addr_low = 4 * q`
- Reused the existing `Range128Chip` lookup to prove `q` is an actual small integer, not an arbitrary field value.
- Added focused regression tests for unaligned `LH`, `LW`, and `SH`, plus aligned acceptance checks for `LH` and `LW`.

## Review notes

The range check is the key part of the fix. Without it, the equality constraint alone would still allow a forged trace to use a fractional field value for `q`. With `q` constrained to `[0, 127]`, the equations force the low address byte to be correctly aligned.

`RamBaseAddr` limbs are already byte-ranged elsewhere, so enforcing the low byte is enough for these alignment rules.

## Verification

Ran locally with the pinned `nightly-2025-05-09-x86_64-pc-windows-gnu` toolchain:

- `cargo fmt --all --check`
- `cargo test -p nexus-vm-prover aligned -- --nocapture`

The focused test run passed with 4 tests passing and 0 failures. The rejection tests intentionally catch AIR constraint failures from malformed traces, so the panic messages printed during those tests are expected.